### PR TITLE
修復 macOS 串流模型自動下載

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -51,6 +51,13 @@ contextBridge.exposeInMainWorld("electronAPI", {
   streamingFeed: (audioChunk, isFinal) => ipcRenderer.invoke("streaming-feed", audioChunk, isFinal),
   streamingEnd: () => ipcRenderer.invoke("streaming-end"),
   preloadStreamingModel: () => ipcRenderer.invoke("preload-streaming-model"),
+  checkStreamingModelFiles: () => ipcRenderer.invoke("check-streaming-model-files"),
+  downloadStreamingModel: () => ipcRenderer.invoke("download-streaming-model"),
+  onStreamingModelDownloadProgress: (callback) => {
+    const handler = (_event, progress) => callback(progress);
+    ipcRenderer.on("streaming-model-download-progress", handler);
+    return () => ipcRenderer.removeListener("streaming-model-download-progress", handler);
+  },
 
   // 模型文件管理
   checkModelFiles: () => ipcRenderer.invoke("check-model-files"),

--- a/sherpa_server.py
+++ b/sherpa_server.py
@@ -881,6 +881,7 @@ class SherpaServer:
         try:
             import time
             start_time = time.time()
+            self.streaming_model_dir = self._find_streaming_model_dir()
             logger.info(f"正在初始化串流辨識器，模型目錄: {self.streaming_model_dir}")
 
             # 檢查模型文件 - 暫時優先使用 fp32 模型（較準確）

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import { useTranslation } from "./i18n";
 import { Mic, MicOff, Settings, Copy, Download, X, Pin, Minus, Sparkles, Minimize2, Maximize2, FileText } from "lucide-react";
 import SettingsPanel from "./components/SettingsPanel";
 import { ModelDownloadProgress } from "./components/ui/model-status-indicator";
+import { resolveStreamingModeAvailability } from "./utils/streamingModeSupport.mjs";
 
 // 动态导入设置页面组件
 const SettingsPage = React.lazy(() => import('./settings.jsx').then(module => ({ default: module.SettingsPage })));
@@ -572,20 +573,33 @@ export default function App() {
 
   // 載入串流模式設定
   useEffect(() => {
+    const resolveStreamingMode = async (enabled) => {
+      const info = window.electronAPI?.getRuntimeInfo?.();
+      return await resolveStreamingModeAvailability(enabled, info, window.electronAPI);
+    };
+
     const loadStreamingMode = async () => {
       if (window.electronAPI) {
         const enabled = await window.electronAPI.getSetting('enable_streaming_mode', false);
-        setStreamingMode(enabled);
+        const streamingAvailability = await resolveStreamingMode(enabled);
+        setStreamingMode(streamingAvailability.enabled);
+        if (enabled && streamingAvailability.unsupported) {
+          await window.electronAPI.setSetting?.('enable_streaming_mode', false);
+        }
       }
     };
     loadStreamingMode();
 
     // 監聽設定變更事件（跨視窗同步）
     if (window.electronAPI?.onSettingChanged) {
-      const unsubscribe = window.electronAPI.onSettingChanged((data) => {
+      const unsubscribe = window.electronAPI.onSettingChanged(async (data) => {
         if (data.key === 'enable_streaming_mode') {
-          setStreamingMode(data.value);
-          console.log('串流模式已更新:', data.value);
+          const streamingAvailability = await resolveStreamingMode(data.value);
+          setStreamingMode(streamingAvailability.enabled);
+          if (data.value && streamingAvailability.unsupported) {
+            await window.electronAPI.setSetting?.('enable_streaming_mode', false);
+          }
+          console.log('串流模式已更新:', streamingAvailability.enabled);
         }
       });
       return () => {

--- a/src/helpers/ipc/transcription.js
+++ b/src/helpers/ipc/transcription.js
@@ -191,6 +191,26 @@ module.exports = function register(ctx) {
     }
   });
 
+  ipcMain.handle("check-streaming-model-files", async () => {
+    try {
+      return await ctx.sherpaManager.checkStreamingModelFiles();
+    } catch (error) {
+      ctx.logger.error("檢查串流模型失敗:", error);
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle("download-streaming-model", async (event) => {
+    try {
+      return await ctx.sherpaManager.downloadStreamingModel((progress) => {
+        event.sender.send("streaming-model-download-progress", progress);
+      });
+    } catch (error) {
+      ctx.logger.error("下載串流模型失敗:", error);
+      return { success: false, error: error.message };
+    }
+  });
+
   // 重新辨識：用保存的原始錄音重跑，更新該筆文字
   ipcMain.handle("retranscribe-transcription", async (event, id, options = {}) => {
     try {

--- a/src/helpers/sherpaManager.js
+++ b/src/helpers/sherpaManager.js
@@ -1,5 +1,6 @@
 const { spawn } = require("child_process");
 const fs = require("fs");
+const https = require("https");
 const path = require("path");
 const crypto = require("crypto");
 const os = require("os");
@@ -10,10 +11,26 @@ let globalModelCheckCache = null;
 let globalModelCheckTime = 0;
 const GLOBAL_CACHE_TIME = 2000; // 2秒緩存
 
+const STREAMING_MODEL_CONFIG = {
+  name: "sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20",
+  url: "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20.tar.bz2",
+  required_files: [
+    "encoder-epoch-99-avg-1.onnx",
+    "decoder-epoch-99-avg-1.onnx",
+    "joiner-epoch-99-avg-1.onnx",
+    "tokens.txt",
+  ],
+};
+
 class SherpaManager {
-  constructor(logger = null) {
+  constructor(logger = null, options = {}) {
     this.logger = logger || console;
     this.pythonResolver = new PythonResolver(this.logger);
+    this.platform = options.platform || process.platform;
+    this.userDataPath = options.userDataPath || null;
+    this.projectRoot = options.projectRoot || path.join(__dirname, "..", "..");
+    this.spawnFn = options.spawnFn || spawn;
+    this.httpsGet = options.httpsGet || https.get;
     this.sherpaInstalled = null;
     this.isInitialized = false;
     this.modelsInitialized = false;
@@ -28,6 +45,7 @@ class SherpaManager {
       expected_size: 223 * 1024 * 1024, // 約 223MB
       required_files: ["model.int8.onnx", "tokens.txt"],
     };
+    this.streamingModelConfig = STREAMING_MODEL_CONFIG;
   }
 
   getSherpaServerPath() {
@@ -99,6 +117,190 @@ class SherpaManager {
 
     // 默認返回 poc-sherpa 路徑（可能需要下載）
     return path.join(__dirname, "..", "..", "poc-sherpa", name);
+  }
+
+  getUserDataPath() {
+    if (this.userDataPath) return this.userDataPath;
+    return require("electron").app.getPath("userData");
+  }
+
+  isStreamingSupportedPlatform() {
+    return this.platform === "darwin";
+  }
+
+  getStreamingModelTargetPath() {
+    const userData = this.getUserDataPath();
+    return path.join(userData, "models", "poc-sherpa", this.streamingModelConfig.name);
+  }
+
+  getStreamingModelSearchPaths() {
+    const name = this.streamingModelConfig.name;
+    const candidates = [];
+    try {
+      candidates.push(this.getStreamingModelTargetPath());
+    } catch (error) {
+      // Non-Electron tests or early startup can still use project fallback.
+    }
+    candidates.push(path.join(this.projectRoot, "poc-sherpa", name));
+    return candidates;
+  }
+
+  findStreamingModelPath() {
+    for (const candidate of this.getStreamingModelSearchPaths()) {
+      const hasAllFiles = this.streamingModelConfig.required_files.every((file) =>
+        fs.existsSync(path.join(candidate, file))
+      );
+      if (hasAllFiles) return candidate;
+    }
+    try {
+      return this.getStreamingModelTargetPath();
+    } catch (error) {
+      return path.join(this.projectRoot, "poc-sherpa", this.streamingModelConfig.name);
+    }
+  }
+
+  async checkStreamingModelFiles() {
+    if (!this.isStreamingSupportedPlatform()) {
+      return {
+        success: false,
+        unsupported: true,
+        models_downloaded: false,
+        error: "Streaming Zipformer is currently available on macOS only",
+      };
+    }
+
+    const modelPath = this.findStreamingModelPath();
+    const missingFiles = this.streamingModelConfig.required_files.filter((file) =>
+      !fs.existsSync(path.join(modelPath, file))
+    );
+
+    return {
+      success: true,
+      unsupported: false,
+      models_downloaded: missingFiles.length === 0,
+      missing_models: missingFiles.length > 0 ? ["streaming"] : [],
+      details: {
+        model_path: modelPath,
+        missing_files: missingFiles,
+        download_url: this.streamingModelConfig.url,
+      },
+    };
+  }
+
+  async downloadStreamingModel(progressCallback = null) {
+    if (!this.isStreamingSupportedPlatform()) {
+      return {
+        success: false,
+        unsupported: true,
+        error: "Streaming Zipformer is currently available on macOS only",
+      };
+    }
+
+    const existing = await this.checkStreamingModelFiles();
+    if (existing.models_downloaded) {
+      return { success: true, already_downloaded: true, model_path: existing.details.model_path };
+    }
+
+    const targetRoot = path.dirname(this.getStreamingModelTargetPath());
+    await fs.promises.mkdir(targetRoot, { recursive: true });
+    const tarPath = path.join(os.tmpdir(), `${this.streamingModelConfig.name}-${crypto.randomUUID()}.tar.bz2`);
+
+    try {
+      await this.downloadFile(this.streamingModelConfig.url, tarPath, progressCallback);
+      progressCallback?.({ stage: "extracting", model: "streaming", progress: 100 });
+      await this.extractTarBz2(tarPath, targetRoot);
+      progressCallback?.({ stage: "verifying", model: "streaming", progress: 100 });
+      const checkResult = await this.checkStreamingModelFiles();
+      if (!checkResult.models_downloaded) {
+        return {
+          success: false,
+          error: `Streaming model download incomplete: ${checkResult.details.missing_files.join(", ")}`,
+          ...checkResult,
+        };
+      }
+      return { success: true, model_path: checkResult.details.model_path };
+    } finally {
+      fs.promises.unlink(tarPath).catch(() => {});
+    }
+  }
+
+  async ensureStreamingModelAvailable(progressCallback = null) {
+    const status = await this.checkStreamingModelFiles();
+    if (status.models_downloaded) {
+      return { success: true, already_downloaded: true, model_path: status.details.model_path };
+    }
+    if (status.unsupported) {
+      return status;
+    }
+    return await this.downloadStreamingModel(progressCallback);
+  }
+
+  downloadFile(url, destPath, progressCallback = null) {
+    return new Promise((resolve, reject) => {
+      const file = fs.createWriteStream(destPath);
+      const request = this.httpsGet(url, (response) => {
+        if (response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
+          file.close();
+          fs.promises.unlink(destPath).catch(() => {});
+          this.downloadFile(response.headers.location, destPath, progressCallback).then(resolve, reject);
+          return;
+        }
+        if (response.statusCode !== 200) {
+          file.close();
+          reject(new Error(`Download failed with HTTP ${response.statusCode}`));
+          return;
+        }
+
+        const total = Number(response.headers["content-length"] || 0);
+        let downloaded = 0;
+        response.on("data", (chunk) => {
+          downloaded += chunk.length;
+          if (progressCallback && total > 0) {
+            progressCallback({
+              stage: "downloading",
+              model: "streaming",
+              downloaded,
+              total,
+              progress: Math.round((downloaded / total) * 1000) / 10,
+            });
+          }
+        });
+        response.pipe(file);
+        file.on("finish", () => {
+          file.close(resolve);
+        });
+      });
+      request.on("error", (error) => {
+        file.close();
+        fs.promises.unlink(destPath).catch(() => {});
+        reject(error);
+      });
+      file.on("error", (error) => {
+        request.destroy();
+        reject(error);
+      });
+    });
+  }
+
+  extractTarBz2(tarPath, targetRoot) {
+    return new Promise((resolve, reject) => {
+      const child = this.spawnFn("tar", ["-xjf", tarPath, "-C", targetRoot], {
+        stdio: ["ignore", "ignore", "pipe"],
+        windowsHide: true,
+      });
+      let stderr = "";
+      child.stderr.on("data", (data) => {
+        stderr += data.toString();
+      });
+      child.on("error", reject);
+      child.on("close", (code) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(stderr.trim() || `tar exited with code ${code}`));
+        }
+      });
+    });
   }
 
   async checkModelFiles() {
@@ -858,6 +1060,11 @@ class SherpaManager {
    * @returns {Promise<{success: boolean, sessionId: string}>}
    */
   async streamingStart(options = {}) {
+    const modelStatus = await this.ensureStreamingModelAvailable();
+    if (!modelStatus.success) {
+      return modelStatus;
+    }
+
     if (!this.serverReady) {
       if (this.initializationPromise) {
         await this.initializationPromise;
@@ -999,6 +1206,11 @@ class SherpaManager {
    * @returns {Promise<{success: boolean}>}
    */
   async preloadStreamingModel() {
+    const modelStatus = await this.ensureStreamingModelAvailable();
+    if (!modelStatus.success) {
+      return modelStatus;
+    }
+
     if (!this.serverReady) {
       if (this.initializationPromise) {
         await this.initializationPromise;

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -147,6 +147,15 @@ export default {
     streamingPreloadComplete: 'Streaming model preloaded',
     streamingPreloadFailed: 'Failed to preload streaming model: {error}',
     streamingPreloadFailedSlow: 'Failed to preload the streaming model; the first recording may be slower',
+    streamingModelMissing: 'Streaming model is not downloaded yet. It will download automatically the first time you enable it.',
+    streamingModelPresent: 'Streaming model is downloaded.',
+    streamingModelDownloading: 'Downloading the streaming model. Please stay connected.',
+    streamingModelDownloadingProgress: 'Downloading streaming model: {progress}%',
+    streamingModelExtracting: 'Download complete. Extracting the streaming model...',
+    streamingModelVerifying: 'Verifying streaming model files...',
+    streamingModelPreloadingStatus: 'Model downloaded. Preloading streaming recognizer...',
+    streamingModelDownloaded: 'Streaming model downloaded',
+    streamingModelDownloadFailed: 'Failed to download streaming model: {error}',
 
     // Window controls
     windowControl: '🪟 Window Controls',

--- a/src/i18n/zh-CN.js
+++ b/src/i18n/zh-CN.js
@@ -147,6 +147,15 @@ export default {
     streamingPreloadComplete: '流式模型预加载完成',
     streamingPreloadFailed: '流式模型预加载失败: {error}',
     streamingPreloadFailedSlow: '流式模型预加载失败，首次录音可能会较慢',
+    streamingModelMissing: '流式模型尚未下载，首次开启时会自动下载。',
+    streamingModelPresent: '流式模型已下载。',
+    streamingModelDownloading: '正在下载流式模型，请保持网络连接。',
+    streamingModelDownloadingProgress: '流式模型下载中：{progress}%',
+    streamingModelExtracting: '下载完成，正在解压流式模型...',
+    streamingModelVerifying: '正在验证流式模型文件...',
+    streamingModelPreloadingStatus: '模型已下载，正在预加载流式识别器...',
+    streamingModelDownloaded: '流式模型下载完成',
+    streamingModelDownloadFailed: '流式模型下载失败: {error}',
 
     // 窗口控制
     windowControl: '🪟 窗口控制',

--- a/src/i18n/zh-TW.js
+++ b/src/i18n/zh-TW.js
@@ -147,6 +147,15 @@ export default {
     streamingPreloadComplete: '串流模型預載完成',
     streamingPreloadFailed: '串流模型預載失敗: {error}',
     streamingPreloadFailedSlow: '串流模型預載失敗，首次錄音可能會較慢',
+    streamingModelMissing: '串流模型尚未下載，首次開啟時會自動下載。',
+    streamingModelPresent: '串流模型已下載。',
+    streamingModelDownloading: '正在下載串流模型，請保持網路連線。',
+    streamingModelDownloadingProgress: '串流模型下載中：{progress}%',
+    streamingModelExtracting: '下載完成，正在解壓串流模型...',
+    streamingModelVerifying: '正在驗證串流模型檔案...',
+    streamingModelPreloadingStatus: '模型已下載，正在預載串流辨識器...',
+    streamingModelDownloaded: '串流模型下載完成',
+    streamingModelDownloadFailed: '串流模型下載失敗: {error}',
 
     // 視窗控制
     windowControl: '🪟 視窗控制',

--- a/src/settings.jsx
+++ b/src/settings.jsx
@@ -55,8 +55,13 @@ const SettingsPage = () => {
   const [saving, setSaving] = useState(false);
   const [showApiKey, setShowApiKey] = useState(false);
   const [testing, setTesting] = useState(false);
+  const [streamingModelStatus, setStreamingModelStatus] = useState(null);
+  const [streamingModelDownloading, setStreamingModelDownloading] = useState(false);
+  const [streamingModelProgress, setStreamingModelProgress] = useState(0);
+  const [streamingModelPhase, setStreamingModelPhase] = useState(null);
   const [testResult, setTestResult] = useState(null);
   const [micDevices, setMicDevices] = useState([]); // 可選的麥克風清單
+  const [runtimeInfo, setRuntimeInfo] = useState(null);
 
   // 权限管理
   const showAlert = (alert) => {
@@ -76,6 +81,41 @@ const SettingsPage = () => {
   // 加载设置
   useEffect(() => {
     loadSettings();
+  }, []);
+
+  useEffect(() => {
+    try {
+      const info = window.electronAPI?.getRuntimeInfo?.();
+      if (info) setRuntimeInfo(info);
+    } catch (e) {
+      setRuntimeInfo(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadStreamingModelStatus = async () => {
+      try {
+        if (!window.electronAPI?.checkStreamingModelFiles) return;
+        const status = await window.electronAPI.checkStreamingModelFiles();
+        if (!cancelled) setStreamingModelStatus(status);
+      } catch (e) {
+        if (!cancelled) setStreamingModelStatus(null);
+      }
+    };
+    loadStreamingModelStatus();
+    const cleanup = window.electronAPI?.onStreamingModelDownloadProgress?.((progress) => {
+      if (progress?.stage) {
+        setStreamingModelPhase(progress.stage);
+      }
+      if (progress?.progress != null) {
+        setStreamingModelProgress(progress.progress);
+      }
+    });
+    return () => {
+      cancelled = true;
+      cleanup?.();
+    };
   }, []);
 
   // 列出可選的麥克風（已授權的話會有名稱；沒授權則只有編號）
@@ -176,6 +216,30 @@ const SettingsPage = () => {
     try { await window.electronAPI?.setSetting?.(key, value); } catch (e) { /* ignore */ }
   };
 
+  const prepareStreamingModel = async () => {
+    const status = await window.electronAPI?.checkStreamingModelFiles?.();
+    setStreamingModelStatus(status || null);
+
+    if (!status?.models_downloaded) {
+      setStreamingModelDownloading(true);
+      setStreamingModelProgress(0);
+      setStreamingModelPhase('downloading');
+      toast.info(t('settings.streamingModelDownloading'));
+      const downloadResult = await window.electronAPI?.downloadStreamingModel?.();
+      if (!downloadResult?.success) {
+        toast.error(t('settings.streamingModelDownloadFailed', { error: downloadResult?.error || t('settings.testFailedDesc') }));
+        return downloadResult || { success: false, error: t('settings.testFailedDesc') };
+      }
+      const nextStatus = await window.electronAPI?.checkStreamingModelFiles?.();
+      setStreamingModelStatus(nextStatus || null);
+      toast.success(t('settings.streamingModelDownloaded'));
+    }
+
+    setStreamingModelPhase('preloading');
+    toast.info(t('settings.streamingPreloading'));
+    return await window.electronAPI.preloadStreamingModel();
+  };
+
   // 处理开关切换并自动保存
   const handleToggleChange = async (key, value) => {
     setSettings(prev => ({
@@ -196,8 +260,7 @@ const SettingsPage = () => {
           toast.success(value ? t('settings.streamingEnabled') : t('settings.streamingDisabled'));
           // 當啟用串流模式時，預載串流模型以減少首次錄音延遲
           if (value) {
-            toast.info(t('settings.streamingPreloading'));
-            window.electronAPI.preloadStreamingModel()
+            prepareStreamingModel()
               .then(result => {
                 if (result.success) {
                   if (result.already_loaded) {
@@ -212,6 +275,11 @@ const SettingsPage = () => {
               .catch(err => {
                 console.error('預載串流模型失敗:', err);
                 toast.error(t('settings.streamingPreloadFailedSlow'));
+              })
+              .finally(() => {
+                setStreamingModelDownloading(false);
+                setStreamingModelProgress(0);
+                setStreamingModelPhase(null);
               });
           }
         } else if (key === 'window_always_on_top') {
@@ -629,6 +697,21 @@ const SettingsPage = () => {
                     <p className="text-xs text-orange-500 dark:text-orange-400 mt-0.5">
                       {t('settings.streamingModeDesc')}
                     </p>
+                    {runtimeInfo?.platform === 'darwin' && streamingModelStatus && (
+                      <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                        {streamingModelPhase === 'extracting'
+                          ? t('settings.streamingModelExtracting')
+                          : streamingModelPhase === 'verifying'
+                            ? t('settings.streamingModelVerifying')
+                            : streamingModelPhase === 'preloading'
+                              ? t('settings.streamingModelPreloadingStatus')
+                              : streamingModelDownloading
+                                ? t('settings.streamingModelDownloadingProgress', { progress: Math.round(streamingModelProgress) })
+                                : streamingModelStatus.models_downloaded
+                                  ? t('settings.streamingModelPresent')
+                                  : t('settings.streamingModelMissing')}
+                      </p>
+                    )}
                   </div>
                   <button
                     type="button"

--- a/src/utils/streamingModeSupport.mjs
+++ b/src/utils/streamingModeSupport.mjs
@@ -1,0 +1,38 @@
+export function shouldEnableStreamingMode(settingEnabled, streamingModelStatus, runtimeInfo) {
+  if (settingEnabled !== true) return false;
+  if (runtimeInfo?.platform !== "darwin") return false;
+  return streamingModelStatus?.success === true && streamingModelStatus?.models_downloaded === true;
+}
+
+export async function resolveStreamingModeAvailability(settingEnabled, runtimeInfo, api) {
+  if (settingEnabled !== true) {
+    return { enabled: false, downloaded: false, status: null };
+  }
+  if (runtimeInfo?.platform !== "darwin") {
+    return { enabled: false, downloaded: false, unsupported: true, status: null };
+  }
+
+  const status = await api?.checkStreamingModelFiles?.();
+  if (shouldEnableStreamingMode(settingEnabled, status, runtimeInfo)) {
+    return { enabled: true, downloaded: false, status };
+  }
+  if (status?.unsupported) {
+    return { enabled: false, downloaded: false, unsupported: true, status };
+  }
+  if (status?.success !== true || typeof api?.downloadStreamingModel !== "function") {
+    return { enabled: false, downloaded: false, status };
+  }
+
+  const downloadResult = await api.downloadStreamingModel();
+  if (!downloadResult?.success) {
+    return { enabled: false, downloaded: false, status, downloadResult };
+  }
+
+  const nextStatus = await api.checkStreamingModelFiles?.();
+  return {
+    enabled: shouldEnableStreamingMode(settingEnabled, nextStatus, runtimeInfo),
+    downloaded: true,
+    status: nextStatus,
+    downloadResult,
+  };
+}

--- a/test/streaming-mode-support.test.js
+++ b/test/streaming-mode-support.test.js
@@ -1,0 +1,50 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const supportModule = import("../src/utils/streamingModeSupport.mjs");
+
+test("streaming mode stays disabled when the model is missing", async () => {
+  const { shouldEnableStreamingMode } = await supportModule;
+
+  assert.equal(
+    shouldEnableStreamingMode(true, { success: true, models_downloaded: false }, { platform: "darwin" }),
+    false
+  );
+  assert.equal(
+    shouldEnableStreamingMode(true, { success: true, models_downloaded: true }, { platform: "win32" }),
+    false
+  );
+});
+
+test("streaming mode can enable only on macOS with downloaded model", async () => {
+  const { shouldEnableStreamingMode } = await supportModule;
+
+  assert.equal(
+    shouldEnableStreamingMode(true, { success: true, models_downloaded: true }, { platform: "darwin" }),
+    true
+  );
+  assert.equal(shouldEnableStreamingMode(false, null, { platform: "darwin" }), false);
+});
+
+test("streaming mode auto-downloads missing macOS model when the saved setting is enabled", async () => {
+  const { resolveStreamingModeAvailability } = await supportModule;
+  const calls = [];
+  const api = {
+    checkStreamingModelFiles: async () => {
+      calls.push("check");
+      return calls.length === 1
+        ? { success: true, unsupported: false, models_downloaded: false }
+        : { success: true, unsupported: false, models_downloaded: true };
+    },
+    downloadStreamingModel: async () => {
+      calls.push("download");
+      return { success: true };
+    },
+  };
+
+  const result = await resolveStreamingModeAvailability(true, { platform: "darwin" }, api);
+
+  assert.equal(result.enabled, true);
+  assert.equal(result.downloaded, true);
+  assert.deepEqual(calls, ["check", "download", "check"]);
+});

--- a/test/streaming-model-download.test.js
+++ b/test/streaming-model-download.test.js
@@ -1,0 +1,106 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const SherpaManager = require("../src/helpers/sherpaManager");
+
+test("streaming model files are checked in userData on macOS", async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "speakslow-streaming-"));
+  const manager = new SherpaManager(null, {
+    platform: "darwin",
+    userDataPath: tmp,
+    projectRoot: path.join(tmp, "project"),
+  });
+
+  const result = await manager.checkStreamingModelFiles();
+
+  assert.equal(result.success, true);
+  assert.equal(result.models_downloaded, false);
+  assert.equal(result.unsupported, false);
+  assert.equal(
+    result.details.model_path,
+    path.join(tmp, "models", "poc-sherpa", "sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20")
+  );
+  assert.deepEqual(result.details.missing_files, [
+    "encoder-epoch-99-avg-1.onnx",
+    "decoder-epoch-99-avg-1.onnx",
+    "joiner-epoch-99-avg-1.onnx",
+    "tokens.txt",
+  ]);
+});
+
+test("streaming model download is disabled on Windows", async () => {
+  const manager = new SherpaManager(null, {
+    platform: "win32",
+    userDataPath: os.tmpdir(),
+  });
+
+  const checkResult = await manager.checkStreamingModelFiles();
+  const downloadResult = await manager.downloadStreamingModel();
+
+  assert.equal(checkResult.success, false);
+  assert.equal(checkResult.unsupported, true);
+  assert.equal(downloadResult.success, false);
+  assert.equal(downloadResult.unsupported, true);
+});
+
+test("preloading streaming model downloads missing macOS model before initializing", async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "speakslow-streaming-preload-"));
+  const calls = [];
+  const manager = new SherpaManager(null, {
+    platform: "darwin",
+    userDataPath: tmp,
+    projectRoot: path.join(tmp, "project"),
+  });
+  manager.serverReady = true;
+  manager.downloadStreamingModel = async () => {
+    calls.push("download");
+    const modelDir = manager.getStreamingModelTargetPath();
+    await fs.promises.mkdir(modelDir, { recursive: true });
+    await Promise.all(manager.streamingModelConfig.required_files.map((file) =>
+      fs.promises.writeFile(path.join(modelDir, file), "model")
+    ));
+    return { success: true, model_path: modelDir };
+  };
+  manager._sendServerCommand = async (command) => {
+    calls.push(command.action);
+    return { success: true };
+  };
+
+  const result = await manager.preloadStreamingModel();
+
+  assert.equal(result.success, true);
+  assert.deepEqual(calls, ["download", "init_streaming"]);
+});
+
+test("streaming model download reports extracting and verifying after file download reaches 100 percent", async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "speakslow-streaming-progress-"));
+  const progressEvents = [];
+  const manager = new SherpaManager(null, {
+    platform: "darwin",
+    userDataPath: tmp,
+    projectRoot: path.join(tmp, "project"),
+  });
+
+  manager.downloadFile = async (_url, _destPath, progressCallback) => {
+    progressCallback?.({ stage: "downloading", model: "streaming", progress: 100 });
+  };
+  manager.extractTarBz2 = async () => {
+    const modelDir = manager.getStreamingModelTargetPath();
+    await fs.promises.mkdir(modelDir, { recursive: true });
+    await Promise.all(manager.streamingModelConfig.required_files.map((file) =>
+      fs.promises.writeFile(path.join(modelDir, file), "model")
+    ));
+  };
+
+  const result = await manager.downloadStreamingModel((event) => progressEvents.push(event));
+
+  assert.equal(result.success, true);
+  assert.deepEqual(progressEvents.map((event) => event.stage), [
+    "downloading",
+    "extracting",
+    "verifying",
+  ]);
+});


### PR DESCRIPTION
## 摘要
- macOS 啟用 Sherpa/Zipformer 串流模式時，若串流模型不存在，會自動下載到使用者資料目錄，不需要打包進 App。
- 新增串流模型檢查與下載 IPC，設定頁會顯示下載、解壓、驗證、預載等狀態，避免 100% 後看起來像卡住。
- Python 後端在初始化串流辨識器前會重新查找模型路徑，確保 App 啟動後才下載的模型也能被找到。

## 測試
- node --test test/*.test.js
- npm run build:renderer

## 備註
- 原本英文描述的 PR #8 已關閉，這個 PR 改用中文描述重新提交。
- 這個分支是從 origin/main 乾淨切出，只包含 macOS 串流模型自動下載相關修正。