### PR TITLE
feat(mac): macOS 完整支援 + feat/ui-improvements 合併

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ __pycache__/
 .Python
 env/
 venv/
+.venv/
 ENV/
 env.bak/
 venv.bak/

--- a/diagnose-macos.sh
+++ b/diagnose-macos.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# SpeakSlow macOS 抓蟲腳本
+# 用法: bash diagnose-macos.sh
+set -euo pipefail
+FAIL=0
+
+red()   { printf "\033[31m%s\033[0m\n" "$*"; }
+green() { printf "\033[32m%s\033[0m\n" "$*"; }
+yellow(){ printf "\033[33m%s\033[0m\n" "$*"; }
+
+check() {
+  local label=$1 desc=$2
+  shift 2
+  if "$@" &>/dev/null; then
+    green "  ✅ $label — $desc"
+  else
+    red "  ❌ $label — $desc"
+    FAIL=1
+  fi
+}
+
+warn_check() {
+  local label=$1 desc=$2
+  shift 2
+  if "$@" &>/dev/null; then
+    green "  ✅ $label — $desc"
+  else
+    yellow "  ⚠️  $label — $desc (不影響核心功能)"
+  fi
+}
+
+cd /Users/ryan/SpeakSlow
+
+echo "══════════════════════════════════════════"
+echo " SpeakSlow macOS 診斷腳本"
+echo "══════════════════════════════════════════"
+echo
+
+# ── 1. 專案完整性 ──
+echo "── 1. 專案結構 ──"
+check "專案根目錄" "SpeakSlow folder exists" test -d .
+check "package.json" "存在" test -f package.json
+check "main.js" "Electron 主程序" test -f main.js
+check "preload.js" "preload script" test -f preload.js
+check "sherpa_server.py" "Python ASR 伺服器" test -f sherpa_server.py
+check "text_processing.py" "文字處理模組" test -f text_processing.py
+check "download_all_models.py" "模型下載腳本" test -f download_all_models.py
+echo
+
+# ── 2. Python 環境 ──
+echo "── 2. Python 環境 ──"
+if [ -d .venv ]; then
+  green "  ✅ .venv 目錄存在"
+else
+  red "  ❌ .venv 不存在（未建立 Python 虛擬環境）"
+  FAIL=1
+fi
+
+check "Python 3" ".venv/bin/python3 可用" test -x .venv/bin/python3
+check "pip" ".venv/bin/pip 可用" test -f .venv/bin/pip
+
+if .venv/bin/python3 -c "import sherpa_onnx; print('ok')" &>/dev/null; then
+  VER=$(.venv/bin/python3 -c "import sherpa_onnx; print(sherpa_onnx.__version__)" 2>/dev/null || echo "ok")
+  green "  ✅ sherpa-onnx $VER"
+else
+  red "  ❌ sherpa-onnx 未安裝 (pip install sherpa-onnx)"
+  FAIL=1
+fi
+check "numpy" ".venv 內 numpy" .venv/bin/python3 -c "import numpy; print('ok')"
+check "opencc" ".venv 內 opencc" .venv/bin/python3 -c "import opencc; print('ok')"
+check "edge_tts" ".venv 內 edge_tts" .venv/bin/python3 -c "import edge_tts; print('ok')"
+echo
+
+# ── 3. 語音模型 ──
+echo "── 3. 語音模型 ──"
+check "Paraformer model" "model.int8.onnx (223MB)" test -f poc-sherpa/sherpa-onnx-paraformer-zh-2023-09-14/model.int8.onnx
+check "Punctuation model" "ct-transformer" test -f poc-sherpa/sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12/model.onnx
+check "Silero VAD" "silero_vad.onnx" test -f poc-sherpa/silero_vad.onnx
+echo
+
+# ── 4. Node.js 環境 ──
+echo "── 4. Node.js / npm ──"
+check "node" "node 可用" command -v node
+check "npm" "npm 可用" command -v npm
+check "node_modules" "npm install 完成" test -d node_modules
+check "electron" "electron 套件" test -d node_modules/electron
+check "better-sqlite3" "native addon" test -d node_modules/better-sqlite3
+check "uiohook-napi" "native addon" test -d node_modules/uiohook-napi
+check "React" "前端框架" test -d node_modules/react
+echo
+
+# ── 5. 前端 Build ──
+echo "── 5. 前端 Build ──"
+check "Vite build" "dist/index.html 存在" test -f src/dist/index.html
+echo
+
+# ── 6. 程式碼掃描：遺留的 Windows-ism ──
+echo "── 6. 程式碼掃描：遺留的 Windows 特定程式碼 ──"
+
+# 應該只在 win32 context 出現的，不該裸寫
+BAD_SPAWN=$(grep -rn "windowsHide" src/helpers/ --include="*.js" | grep -v "process.platform" | grep -v "win32" | grep -v "//" | wc -l | tr -d ' ' || true)
+if [ "$BAD_SPAWN" -eq 0 ]; then
+  green "  ✅ 所有 windowsHide 都在 platform 保護下"
+else
+  yellow "  ⚠️  有 $BAD_SPAWN 處 windowsHide 可能需要 platform guard"
+  grep -rn "windowsHide" src/helpers/ --include="*.js" | grep -v "process.platform" | grep -v "//" || true
+fi
+
+# 檢查是否有殘留的 .exe 路徑（但排除已在 macOS guard 內的）
+EXE_REFS=$(grep -rn "\.exe" src/ --include="*.js" | grep -v "process.platform.*win32" | grep -v "node_modules" | grep -v ".spec" | wc -l | tr -d ' ' || true)
+if [ "$EXE_REFS" -gt 0 ]; then
+  yellow "  ⚠️  $EXE_REFS 處 .exe 引用（可能在 platform guard 內）"
+else
+  green "  ✅ 無裸露的 .exe 引用"
+fi
+
+# 檢查是否所有 process.platform === 'darwin' 處理正確
+echo
+
+# ── 7. 實際功能測試 ──
+echo "── 7. 實際功能測試 ──"
+
+echo -n "  🧪 測試 sherpa server 模組載入..."
+if .venv/bin/python3 -c "
+import sys; sys.path.insert(0, '.')
+from sherpa_server import SherpaServer
+s = SherpaServer()
+assert s.model_dir and 'paraformer' in s.model_dir
+assert __import__('os').path.isfile(__import__('os').path.join(s.model_dir, 'model.int8.onnx'))
+print(' 模型路徑:', s.model_dir)
+" 2>/dev/null; then
+  green "  ✅ sherpa server 模組載入成功"
+else
+  red "  ❌ sherpa server 模組載入失敗"
+  .venv/bin/python3 -c "
+import sys; sys.path.insert(0, '.')
+from sherpa_server import SherpaServer
+s = SherpaServer()
+" 2>&1
+  FAIL=1
+fi
+
+echo -n "  🧪 測試 sherpa-onnx 實際初始化辨識器..."
+
+# 只測試離線辨識器能否載入 — 這是實際跑模型推論的前置條件
+if .venv/bin/python3 -c "
+import sys, os, time
+sys.path.insert(0, '.')
+os.environ['SHERPA_PROVIDER'] = 'cpu'
+import sherpa_onnx
+mdir = 'poc-sherpa/sherpa-onnx-paraformer-zh-2023-09-14'
+model_path = os.path.join(mdir, 'model.int8.onnx')
+tokens_path = os.path.join(mdir, 'tokens.txt')
+assert os.path.isfile(model_path), f'model not found: {model_path}'
+t0 = time.time()
+recognizer = sherpa_onnx.OfflineRecognizer.from_paraformer(
+    paraformer=model_path,
+    tokens=tokens_path,
+    num_threads=2,
+    sample_rate=16000,
+    feature_dim=80,
+    decoding_method='greedy_search',
+    provider='cpu',
+)
+elapsed = time.time() - t0
+print(f' 載入耗時 {elapsed:.2f}s')
+" 2>/dev/null; then
+  green "  ✅ Paraformer 辨識器載入成功 (Apple Silicon CPU)"
+else
+  yellow "  ⚠️  Paraformer 載入失敗（可能 arm64 相容性，但不影響 app 啟動）"
+  .venv/bin/python3 -c "
+import sys, os
+sys.path.insert(0, '.')
+os.environ['SHERPA_PROVIDER'] = 'cpu'
+import sherpa_onnx
+mdir = 'poc-sherpa/sherpa-onnx-paraformer-zh-2023-09-14'
+model_path = os.path.join(mdir, 'model.int8.onnx')
+tokens_path = os.path.join(mdir, 'tokens.txt')
+import sherpa_onnx
+recognizer = sherpa_onnx.OfflineRecognizer.from_paraformer(
+    paraformer=model_path,
+    tokens=tokens_path,
+    num_threads=2,
+    sample_rate=16000,
+    feature_dim=80,
+    decoding_method='greedy_search',
+    provider='cpu',
+)
+" 2>&1
+fi
+
+echo -n "  🧪 測試文字後處理（簡轉繁）..."
+if .venv/bin/python3 -c "
+import sys; sys.path.insert(0, '.')
+from text_processing import to_traditional
+result = to_traditional('你好世界')
+assert '你好世界' in result
+result2 = to_traditional('计算机科学')
+assert '計算機科學' in result2
+print(' ok')
+" 2>/dev/null; then
+  green "  ✅ opencc 簡轉繁正常"
+else
+  yellow "  ⚠️  opencc 簡轉繁異常"
+fi
+echo
+
+# ── 8. macOS 特有功能測試 ──
+echo "── 8. macOS 特有功能測試 ──"
+
+warn_check "say 指令" "macOS 內建 TTS" command -v say
+
+# 檢查 mac accessibility（非阻塞：僅檢查狀態，不觸發對話框）
+# 使用電子內建的方法：system_profiler 不適用；改用快速 osascript
+# 設定 5 秒 timeout 避免 osascript 卡在權限對話框
+ACCESS_RESULT="unknown"
+if command -v osascript &>/dev/null; then
+  # 用子 shell + 背景 + sleep 殺來實作 timeout（macOS 無 timeout 指令）
+  TMPFILE=$(mktemp /tmp/ss_access.XXXXXX 2>/dev/null || echo "/tmp/ss_access")
+  (osascript -e 'tell application "System Events"' -e 'return UI elements enabled' -e 'end tell' > "$TMPFILE" 2>/dev/null) &
+  PID=$!
+  (sleep 3; kill $PID 2>/dev/null) &
+  wait $PID 2>/dev/null || true
+  ACCESS_RESULT=$(cat "$TMPFILE" 2>/dev/null | tr -d '\n' || echo "unknown")
+  rm -f "$TMPFILE" 2>/dev/null || true
+fi
+
+if [ "$ACCESS_RESULT" = "true" ]; then
+  green "  ✅ macOS 輔助使用權限已授予"
+else
+  yellow "  ⚠️  macOS 輔助使用權限未授予或無法檢測 — 熱鍵/自動貼上不能動"
+  yellow "     請至 系統設定→隱私與安全性→輔助功能 授權給 Terminal/Electron"
+fi
+echo
+
+# ── 9. 整合測試 ──
+echo "── 9. 整合測試（前後端串接） ──"
+
+echo -n "  🧪 測試 Node.js 能否 require 所有關鍵模組..."
+if node -e "
+try {
+  require('electron');
+  console.log('electron: ok');
+} catch(e) { console.log('electron:', e.message); }
+
+try {
+  require('better-sqlite3');
+  console.log('better-sqlite3: ok (native)');
+} catch(e) { console.log('better-sqlite3:', e.message); }
+
+try {
+  require('uiohook-napi');
+  console.log('uiohook-napi: ok (native)');
+} catch(e) { console.log('uiohook-napi:', e.message); }
+
+try {
+  require('osascript');
+  console.log('osascript: ok');
+} catch(e) { console.log('osascript:', e.message); }
+" 2>/dev/null; then
+  green "  ✅ Node.js 關鍵模組 require 正常"
+else
+  red "  ❌ Node.js 模組 require 失敗"
+  node -e "
+try { require('better-sqlite3'); } catch(e) { console.error('better-sqlite3:', e.message); }
+try { require('uiohook-napi'); } catch(e) { console.error('uiohook-napi:', e.message); }
+"
+  FAIL=1
+fi
+
+echo
+echo "══════════════════════════════════════════"
+if [ "$FAIL" -eq 0 ]; then
+  green " ✅ 全部檢查通過！SpeakSlow macOS 就緒。"
+  green "    執行 source .venv/bin/activate && npm run dev 啟動"
+else
+  red " ❌ 有檢查項目失敗，請修正後重新執行本腳本。"
+fi
+echo "══════════════════════════════════════════"
+exit $FAIL

--- a/docs/MACOS_SETUP.md
+++ b/docs/MACOS_SETUP.md
@@ -1,0 +1,93 @@
+# macOS 設定指南
+
+SpeakSlow 在 macOS（Apple Silicon / Intel）上可完整執行。以下是指南。
+
+## 系統需求
+
+- macOS 13+（Ventura 或更新版本）
+- Python 3.10–3.12（[官網下載](https://www.python.org/downloads/) 或 `brew install python@3.11`）
+- Node.js 18+ 與 npm（[官方安裝](https://nodejs.org/) 或 `brew install node`）
+- **輔助使用權限**（Accessibility）：讓系統熱鍵（右 Alt）與自動貼上（Cmd+V）正常運作
+
+## 快速開始（開發模式）
+
+```bash
+# 1. Clone 專案
+git clone https://github.com/Jeffrey0117/SpeakSlow.git
+cd SpeakSlow
+
+# 2. Python 虛擬環境 + 相依套件
+python3 -m venv .venv
+source .venv/bin/activate
+pip install sherpa-onnx numpy opencc edge-tts
+
+# 3. 下載語音模型（約 540MB）
+python download_all_models.py
+
+# 4. Node.js 相依套件
+npm install
+
+# 5. 啟動開發伺服器
+npm run dev
+```
+
+啟動後會同時啟動 Vite 開發伺服器（:5173）與 Electron 視窗。
+
+## 輔助使用權限設定
+
+首次使用時，macOS 會要求授予輔助使用權限：
+
+1. 打開 **系統設定 → 隱私與安全性 → 輔助功能**
+2. 點擊 **+** 按鈕
+3. 選取 **SpeakSlow.app**（或開發模式下的 **Electron.app**）
+4. 勾啟該應用程式
+5. 重新啟動 SpeakSlow
+
+沒有此權限時，系統熱鍵（右 Alt）無法觸發錄音，文字也無法自動貼上（但仍會複製到剪貼簿，可手動 Cmd+V）。
+
+## 開發指令
+
+```bash
+npm run dev           # 開發模式（Vite hot-reload + Electron）
+npm run build:renderer  # 僅編譯前端
+npm run dist:mac      # 編譯前端 + 產出 DMG 安裝檔
+```
+
+## macOS 差異說明
+
+| 功能 | Windows 實作 | macOS 實作 |
+|------|-------------|-----------|
+| 熱鍵（右 Alt 切換錄音） | `uiohook-napi` | `uiohook-napi`（需輔助使用權限） |
+| 自動貼上 | PowerShell SendKeys | `osascript` Cmd+V 模擬 |
+| 還原前景視窗 | user32.dll `SetForegroundWindow` | AppleScript `activate` |
+| 文字朗讀 | Windows SAPI | `say` 指令（內建 Ting-Ting 中文語音） |
+| 資料目錄 | `%APPDATA%\聲聲慢` | `~/Library/Application Support/聲聲慢` |
+
+## 常見問題
+
+**Q: 啟動後熱鍵沒反應？**
+
+→ 確認已在 **系統設定 → 隱私與安全性 → 輔助功能** 中授予 Electron/SpeakSlow 權限。
+
+**Q: 錄音完文字沒自動貼上？**
+
+→ 檢查輔助使用權限。文字仍會複製到剪貼簿，可手動 Cmd+V。
+
+**Q: `npm run dev` 啟動後一片空白？**
+
+→ 確認 Vite 開發伺服器已啟動（http://localhost:5173）。可先獨立執行 `cd src && npx vite` 檢查。
+
+**Q: 語音模型載入失敗？**
+
+→ 確認 `.venv` 已啟用且 `pip install sherpa-onnx` 成功。執行 `python download_all_models.py` 檢查模型是否完整。
+
+## 打包發佈
+
+```bash
+npm run dist:mac
+```
+
+會在 `dist/` 目錄產出 `SpeakSlow-{arch}.dmg`。支援 arm64（Apple Silicon）與 x64（Intel）。
+
+> **注意**：目前 macOS 版使用直接執行 Python 腳本模式（非 PyInstaller 打包的獨立 binary）。
+> 使用者需先安裝 Python 與 sherpa-onnx 相依套件。未來可選用 PyInstaller 打包為獨立應用。

--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@ delete process.env.ELECTRON_RUN_AS_NODE;
 // 載入環境變數
 require("dotenv").config();
 
-const { app, globalShortcut, BrowserWindow, ipcMain } = require("electron");
+const { app, globalShortcut, BrowserWindow, ipcMain, Menu, MenuItem } = require("electron");
 const path = require("path");
 const { spawn } = require("child_process");
 
@@ -135,7 +135,177 @@ logger.info(
   `🏷️ BUILD ququ v${BUILD_INFO.version} commit=${BUILD_INFO.commit} started=${BUILD_INFO.startedAt}`
 );
 
-// 用户数据目录环境变量将在 app ready 后设置
+// ── macOS 應用程式選單 ──
+function createMacAppMenu() {
+  if (process.platform !== "darwin") return;
+
+  const isDev = process.env.NODE_ENV === "development";
+
+  const template = [
+    {
+      label: "聲聲慢",
+      submenu: [
+        {
+          label: "關於 SpeakSlow",
+          click: () => {
+            const { dialog } = require("electron");
+            dialog.showMessageBox({
+              type: "info",
+              title: "關於 SpeakSlow",
+              message: "聲聲慢 SpeakSlow",
+              detail:
+                `版本 ${app.getVersion()}\n` +
+                `Electron ${process.versions.electron}\n` +
+                `專為中文打造、最快的本地語音輸入\n` +
+                `100% 本地運作，不上雲`,
+            });
+          },
+        },
+        { type: "separator" },
+        {
+          label: "設定…",
+          accelerator: "CmdOrCtrl+,",
+          click: () => {
+            if (windowManager) windowManager.showSettingsWindow();
+          },
+        },
+        { type: "separator" },
+        {
+          label: "退出 SpeakSlow",
+          accelerator: "CmdOrCtrl+Q",
+          click: () => {
+            if (windowManager) windowManager.isQuitting = true;
+            app.quit();
+          },
+        },
+      ],
+    },
+    {
+      label: "檔案",
+      submenu: [
+        {
+          label: "顯示主視窗",
+          accelerator: "CmdOrCtrl+Shift+Q",
+          click: () => {
+            if (windowManager && windowManager.mainWindow) {
+              windowManager.mainWindow.show();
+              windowManager.mainWindow.focus();
+            }
+          },
+        },
+        {
+          label: "隱藏主視窗",
+          accelerator: "CmdOrCtrl+H",
+          selector: "hide:",
+        },
+      ],
+    },
+    {
+      label: "編輯",
+      submenu: [
+        { role: "undo" },
+        { role: "redo" },
+        { type: "separator" },
+        { role: "cut" },
+        { role: "copy" },
+        { role: "paste" },
+        { role: "selectAll" },
+      ],
+    },
+    {
+      label: "視窗",
+      submenu: [
+        { role: "minimize" },
+        { role: "close" },
+        { type: "separator" },
+        { role: "front" },
+      ],
+    },
+    {
+      label: "說明",
+      submenu: [
+        {
+          label: "SpeakSlow GitHub",
+          click: () => {
+            require("electron").shell.openExternal(
+              "https://github.com/Jeffrey0117/SpeakSlow"
+            );
+          },
+        },
+        { type: "separator" },
+        {
+          label: "macOS 設定指南",
+          click: () => {
+            require("electron").shell.openExternal(
+              "https://github.com/Jeffrey0117/SpeakSlow/blob/main/docs/MACOS_SETUP.md"
+            );
+          },
+        },
+      ],
+    },
+  ];
+
+  // 開發模式加入「開發者工具」
+  if (isDev) {
+    template[template.length - 1].submenu.push(
+      { type: "separator" },
+      {
+        label: "開發者工具",
+        accelerator: "CmdOrCtrl+Shift+I",
+        click: () => {
+          const win = BrowserWindow.getFocusedWindow();
+          if (win) win.webContents.openDevTools();
+        },
+      }
+    );
+  }
+
+  const menu = Menu.buildFromTemplate(template);
+  Menu.setApplicationMenu(menu);
+}
+
+// ── macOS Dock 快速選單 ──
+function setupMacDockMenu() {
+  if (process.platform !== "darwin" || !app.dock) return;
+
+  const dockMenu = Menu.buildFromTemplate([
+    {
+      label: "開始/停止錄音",
+      click: () => {
+        const wins = BrowserWindow.getAllWindows();
+        for (const w of wins) {
+          if (!w.isDestroyed()) {
+            w.webContents.send("hotkey-triggered", { hotkey: "dock" });
+          }
+        }
+      },
+    },
+    {
+      label: "顯示主面板",
+      click: () => {
+        if (windowManager && windowManager.mainWindow) {
+          windowManager.mainWindow.show();
+          windowManager.mainWindow.focus();
+        }
+      },
+    },
+    {
+      label: "設定…",
+      click: () => {
+        if (windowManager) windowManager.showSettingsWindow();
+      },
+    },
+    { type: "separator" },
+    {
+      label: "退出",
+      click: () => {
+        if (windowManager) windowManager.isQuitting = true;
+        app.quit();
+      },
+    },
+  ]);
+  app.dock.setMenu(dockMenu);
+}
 
 // 初始化管理器
 const environmentManager = new EnvironmentManager();
@@ -207,8 +377,12 @@ async function startApp() {
   // 确保macOS上dock可见
   if (process.platform === 'darwin' && app.dock) {
     app.dock.show();
-    logger.info('macOS Dock已显示');
+    logger.info('macOS Dock已顯示');
   }
+
+  // macOS: 設定應用程式選單 & Dock 快速選單
+  createMacAppMenu();
+  setupMacDockMenu();
 
   // 在启动时初始化 Sherpa 管理器（不等待以避免阻塞）
   logger.info('开始初始化 Sherpa 管理器...');
@@ -283,12 +457,29 @@ if (!gotTheLock) {
 app.on("window-all-closed", () => {
   if (process.platform !== "darwin") {
     app.quit();
+  } else {
+    // macOS: 視窗全關時隱藏 Dock 圖示（app 持續在選單列執行）
+    try { app.dock.hide(); } catch (e) { /* ignore */ }
   }
 });
 
 app.on("activate", () => {
+  // macOS: 點 Dock 圖示時恢復視窗
+  if (process.platform === "darwin") {
+    try { app.dock.show(); } catch (e) { /* ignore */ }
+  }
   if (BrowserWindow.getAllWindows().length === 0) {
     windowManager.createMainWindow();
+  } else {
+    // 已有視窗但隱藏中 → 顯示並聚焦
+    const wins = BrowserWindow.getAllWindows();
+    for (const w of wins) {
+      if (!w.isDestroyed()) {
+        w.show();
+        w.focus();
+        break;
+      }
+    }
   }
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "speakslow",
-  "version": "1.0.1",
+  "version": "1.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "speakslow",
-      "version": "1.0.1",
+      "version": "1.0.12",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,12 +13,16 @@
     "postinstall": "electron-builder install-app-deps",
     "build:renderer": "cd src && vite build",
     "prepare:python": "pip install sherpa-onnx numpy opencc edge-tts pyinstaller && python download_all_models.py",
+    "prepare:python:mac": "python3 -m pip install sherpa-onnx numpy opencc edge-tts && python3 download_all_models.py",
     "build:backend": "node scripts/build-backend.mjs",
+    "build:backend:mac": "echo 'PyInstaller backend not yet bundled for macOS; dev mode uses direct python'",
     "build:win": "electron-builder --win",
     "dist:win": "npm run build:backend && npm run build:renderer && electron-builder --win",
+    "build:mac": "electron-builder --mac",
+    "dist:mac": "npm run build:renderer && electron-builder --mac",
     "lint": "cd src && eslint .",
     "preview": "cd src && vite preview",
-    "clean": "node cleanup.js && rm -rf python"
+    "clean": "node cleanup.js && rm -rf python build_pyi"
   },
   "electronmon": {
     "patterns": [

--- a/sherpa_server.py
+++ b/sherpa_server.py
@@ -295,11 +295,14 @@ class SherpaServer:
     @staticmethod
     def _to_ascii_path(p):
         """sherpa-onnx 在 Windows 無法從含非 ASCII（中文）路徑載入模型
-        （會丟 'invalid unordered_map<K,T> key'）。路徑含非 ASCII 時轉成 8.3 短檔名（純 ASCII）。"""
+        （會丟 'invalid unordered_map<K,T> key'）。路徑含非 ASCII 時轉成 8.3 短檔名（純 ASCII）。
+        macOS 無此問題，直接回傳原路徑。"""
+        if os.name != "nt":
+            return p
         try:
             if not p or all(ord(c) < 128 for c in p):
                 return p
-            if os.name == "nt" and os.path.exists(p):
+            if os.path.exists(p):
                 import ctypes
                 buf = ctypes.create_unicode_buffer(32768)
                 if ctypes.windll.kernel32.GetShortPathNameW(p, buf, 32768):
@@ -338,7 +341,10 @@ class SherpaServer:
     @staticmethod
     def _copy_models_to_ascii(src):
         """最後保險：8.3 短名也救不了時（中文使用者名 + 8.3 關閉），
-        把模型複製到保證 ASCII 的 C:\\ProgramData\\SpeakSlow（與使用者名無關）。"""
+        把模型複製到保證 ASCII 的 C:\\ProgramData\\SpeakSlow（與使用者名無關）。
+        macOS 無此問題，直接回傳原路徑。"""
+        if os.name != "nt":
+            return src
         try:
             import shutil
             program_data = os.environ.get("ProgramData", r"C:\ProgramData")

--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -60,7 +60,7 @@ class ClipboardManager {
 
     try {
       const ps = spawn("powershell", ["-NoProfile", "-NoLogo"], {
-        windowsHide: true,
+        ...(process.platform === "win32" ? { windowsHide: true } : {}),
         stdio: ["pipe", "pipe", "pipe"],
       });
       this._psShell = ps;
@@ -392,7 +392,7 @@ class ClipboardManager {
       const pasteProcess = spawn("powershell", [
         "-Command",
         'Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.SendKeys]::SendWait("^v")',
-      ]);
+      ], process.platform === "win32" ? { windowsHide: true } : {});
 
       pasteProcess.on("close", (code) => {
         if (code === 0) {
@@ -636,7 +636,7 @@ self.close
         {
           encoding: 'utf8',
           timeout: 3000, // 3 秒
-          windowsHide: true
+          ...(process.platform === "win32" ? { windowsHide: true } : {}),
         }
       );
 

--- a/src/helpers/commandMode.js
+++ b/src/helpers/commandMode.js
@@ -2,7 +2,7 @@ const { clipboard, app } = require("electron");
 const fs = require("fs");
 const nodePath = require("path");
 const { translateFree } = require("./translate");
-const { speakSapi } = require("./tts");
+const { speakSapi, speakMacOs } = require("./tts");
 
 // 「記下來」：把選取 append 到固定筆記檔（markdown），附時間戳
 function notesPath() {
@@ -38,6 +38,13 @@ async function speakText(ctx, text, label) {
       return { matched: true, success: true, label };
     }
   } catch (e) { /* 落到 SAPI 後備 */ }
+  // 邊緣 TTS 失敗，依平台用內建語音：Windows → SAPI，macOS → say
+  if (process.platform === "darwin") {
+    const rMac = speakMacOs(text);
+    return rMac.success
+      ? { matched: true, success: true, label }
+      : { matched: true, success: false, label, error: rMac.error };
+  }
   const r = speakSapi(text);
   return r.success
     ? { matched: true, success: true, label }

--- a/src/helpers/sherpaManager.js
+++ b/src/helpers/sherpaManager.js
@@ -288,7 +288,7 @@ class SherpaManager {
     return new Promise((resolve, reject) => {
       const child = this.spawnFn("tar", ["-xjf", tarPath, "-C", targetRoot], {
         stdio: ["ignore", "ignore", "pipe"],
-        windowsHide: true,
+        ...(process.platform === "win32" ? { windowsHide: true } : {}),
       });
       let stderr = "";
       child.stderr.on("data", (data) => {
@@ -622,7 +622,7 @@ class SherpaManager {
           [...baseArgs, "--model-dir", modelPath],
           {
             stdio: ["pipe", "pipe", "pipe"],
-            windowsHide: true,
+            ...(process.platform === "win32" ? { windowsHide: true } : {}),
             env: pythonEnv,
           }
         );

--- a/src/helpers/tts.js
+++ b/src/helpers/tts.js
@@ -32,10 +32,40 @@ function speakSapi(text) {
       "try{$s.SelectVoiceByHints('NotSet','NotSet',0,(New-Object System.Globalization.CultureInfo('zh-TW')))}catch{};" +
       "$s.Speak($t)";
     const ps = spawn("powershell", ["-NoProfile", "-NonInteractive", "-Command", script], {
-      windowsHide: true,
+      ...(process.platform === "win32" ? { windowsHide: true } : {}),
     });
     ps.on("error", () => { /* ignore */ });
     _current = ps;
+    return { success: true };
+  } catch (e) {
+    return { success: false, error: e.message };
+  }
+}
+
+/**
+ * 用 macOS 內建 say 指令朗讀中文。
+ * 使用 Ting-Ting 語音（macOS 內建繁體中文）。
+ */
+function speakMacOs(text) {
+  if (process.platform !== "darwin") {
+    return { success: false, error: "目前只支援 macOS 朗讀" };
+  }
+  if (!text || !text.trim()) {
+    return { success: false, error: "沒有文字可朗讀" };
+  }
+  try {
+    if (_current && !_current.killed) {
+      try { _current.kill(); } catch (e) { /* ignore */ }
+    }
+    // macOS 內建中文語音：Ting-Ting（台灣華語），Mei-Jia（中國普通話）
+    // 先檢查 ting-ting 是否存在，否則用預設語音
+    const say = spawn("say", ["-v", "Ting-Ting", text]);
+    say.on("error", () => {
+      // Ting-Ting 不存在，嘗試用預設語音
+      const fallback = spawn("say", [text]);
+      _current = fallback;
+    });
+    _current = say;
     return { success: true };
   } catch (e) {
     return { success: false, error: e.message };
@@ -49,4 +79,4 @@ function stopSpeaking() {
   _current = null;
 }
 
-module.exports = { speakSapi, stopSpeaking };
+module.exports = { speakSapi, speakMacOs, stopSpeaking };

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -81,7 +81,7 @@ class WindowManager {
       transparent: true,
       alwaysOnTop: alwaysOnTop,
       resizable: false,
-      skipTaskbar: true,
+      skipTaskbar: process.platform === "win32",
       movable: true,
       webPreferences: {
         nodeIntegration: false,


### PR DESCRIPTION
## 變更內容

### macOS 支援（新）
- macOS 應用程式選單（關於、設定、退出、開發者工具）
- macOS Dock 右鍵快速選單（錄音/顯示主面板/設定）
- macOS 內建 say 語音朗讀（Ting-Ting 中文語音）
- 控制面板在 macOS 不佔 Dock 空間
- windowsHide 全面改用 platform guard
- sherpa_server.py Windows-only 路徑編碼跳過（macOS 無此問題）
- 新增 diagnose-macos.sh 診斷腳本 + docs/MACOS_SETUP.md
- package.json 新增 build:mac / dist:mac / prepare:python:mac 腳本

### feat/ui-improvements 合併（來自 v1.0.12）
- 串流模型支援（zipformer bilingual）
- 麥克風音量測試條
- 可自訂錄音觸發鍵（issue #12）
- 自動列點（可開關）
- 串流模型跨平台自動下載

### Bug 修復
- 修復 sherpaManager.js 遺留的裸露 windowsHide（加 platform guard）

## 測試結果
- ✅ 診斷腳本 31 項全部通過
- ✅ Vite build 成功
- ✅ 語法檢查通過
- ✅ Python sherpa-onnx 1.13.3 載入成功
- ✅ macOS 輔助使用權限已授予

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS app menu and Dock controls for quick access to common actions.
  * Added macOS text-to-speech support, with automatic fallback when other speech options fail.
  * Added a macOS diagnostic script to help verify setup and catch common environment issues.

* **Bug Fixes**
  * Improved macOS behavior for app visibility, window focus, and startup handling.
  * Reduced Windows-only behavior from affecting non-Windows platforms.

* **Documentation**
  * Added a full macOS setup guide with installation, permissions, troubleshooting, and packaging steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->