### PR TITLE
fix: 熱詞新增後無法儲存（set_hotwords 指令格式與後端不一致）

### DIFF
--- a/src/helpers/sherpaManager.js
+++ b/src/helpers/sherpaManager.js
@@ -1316,9 +1316,11 @@ class SherpaManager {
     try {
       const result = await this._sendServerCommand({
         action: "set_hotwords",
-        enabled: config.enabled,
-        score: config.score,
-        words: config.words,
+        config: {
+          enabled: config.enabled,
+          score: config.score,
+          words: config.words,
+        },
       });
       this.logger.info && this.logger.info("設定熱詞結果:", result);
       return result;


### PR DESCRIPTION
## 問題

在「熱詞設定」頁新增熱詞後，UI 顯示新增成功，但離開頁面再回來就歸零，`hotwords.txt` 也從未被建立。v1.0.14 和 v1.0.18 都能重現。

## 原因

`sherpaManager.setHotwords()` 把欄位放在指令最外層送出：

```js
this._sendServerCommand({ action: "set_hotwords", enabled, score, words })
```

但 `sherpa_server.py` 是從巢狀的 `config` 欄位讀取：

```python
elif action == "set_hotwords":
    config = command.get("config", {})   # 永遠拿到 {}
```

後端收到空設定後什麼都不更新，卻仍回 `success: true`（帶當前記憶體狀態），所以 UI 誤以為成功。log 中只會看到「熱詞檔案不存在」，從未出現 `_save_hotwords_file` 的「儲存 N 個熱詞」。

## 修正

把 JS 端改為與後端協定一致的巢狀格式：`{ action: "set_hotwords", config: { enabled, score, words } }`。

## 驗證

- 直接對 PyInstaller 打包的 `sherpa_server` 送新格式指令：`hotwords.txt` 正確寫入，`get_hotwords` 讀回設定的詞與 score。
- 重新打包 macOS app 後實測：新增熱詞 → 離開設定頁 → 回來，熱詞保留。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hotword configuration handling by sending settings in the format expected by the backend.
  * Preserved existing error handling and command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->