### PR TITLE
fix(mac): 錄音時不再搶走前景焦點（TypeLess 指示器改用 showInactive）

### DIFF
--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -529,14 +529,14 @@ class WindowManager {
     };
     if (this.typelessIndicatorWindow && !this.typelessIndicatorWindow.isDestroyed()) {
       pushState();
-      this.typelessIndicatorWindow.show();
+      this.typelessIndicatorWindow.showInactive();
     } else {
       this.createTypelessIndicatorWindow().then(() => {
         if (this.typelessIndicatorWindow) {
           // 等內容載入完再推狀態，避免訊息早於監聽器
           this.typelessIndicatorWindow.webContents.once("did-finish-load", pushState);
           pushState();
-          this.typelessIndicatorWindow.show();
+          this.typelessIndicatorWindow.showInactive();
         }
       });
     }


### PR DESCRIPTION
## 問題
在 macOS 上，按觸發鍵（右 Option / 右 Ctrl）開始錄音時，SpeakSlow 會被帶到前景、搶走目前使用中 app 的焦點，辨識結束貼字後才跳回原本的 app。這讓「在 ChatGPT / 編輯器裡邊講邊用」的體驗被打斷——每次錄音畫面都會先跳到 SpeakSlow 再跳回來。

## 根因
`showTypelessIndicator()` 用 `BrowserWindow.show()` 顯示錄音指示器。指示器視窗本身雖是 `focusable: false`，但在 macOS 上 `show()` 會觸發 app 層級的 activation，把 SpeakSlow 的可見視窗（控制面板）一起帶到前景。

## 修正
把指示器的 `show()` 改為 `showInactive()`：顯示視窗但不 activate app、不搶焦點。指示器本來就是 `focusable: false` + `alwaysOnTop('screen-saver')`，用 `showInactive()` 完全符合其「浮在最上層、但不奪取焦點」的設計意圖。

## 影響範圍
只改 `src/helpers/windowManager.js` 的 `showTypelessIndicator()` 兩處顯示呼叫，不動辨識、資料、其他視窗行為。

## 測試
- macOS（Apple Silicon）本機打包成 .app 實測。
- 切到其他 app（備忘錄／對話框）游標停在輸入框 → 按右 Option 錄音 → 前景維持在原本的 app，不再跳到 SpeakSlow；指示器照常浮在最上層，辨識與自動貼字正常。

## 平台
`showInactive()` 為 Electron 跨平台標準 API；此變更僅影響指示器視窗顯示方式，未在 Windows 上另行測試。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the typeless indicator’s display behavior so it appears without unexpectedly activating or focusing its window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->