### PR TITLE
fix(clipboard): type text char-by-char so it works in cmd/console windows

### DIFF
--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -82,7 +82,8 @@ class ClipboardManager {
             if (w) {
               this._psWaiters.delete(m[1]);
               clearTimeout(w.timer);
-              w.resolve(m[2] === "OK");
+              // 回傳狀態字串："ok"=確認完成；"err"=已嘗試但可能只完成一半（上層不可再貼上）
+              w.resolve(m[2] === "OK" ? "ok" : "err");
             }
           }
         }
@@ -91,12 +92,14 @@ class ClipboardManager {
         this.safeLog(`⚠️ PS 常駐錯誤: ${d.toString().slice(0, 200)}`);
       });
       const cleanup = () => {
-        // 清掉所有還在等回報的 waiter（清 timer + resolve(false) + 清空 map），
-        // 避免 PS 結束/出錯時有 Promise 卡到各自的 timeout 才 fallback。
+        // 清掉所有還在等回報的 waiter（清 timer + resolve + 清空 map），
+        // 避免 PS 結束/出錯時有 Promise 卡到各自的 timeout。
+        // 用 "failed"（而非 "not-sent"）：指令已送出、PS 中途死掉，可能已打了一半 →
+        // 上層不可再自動 Ctrl+V，以免與已輸入的字重複。
         if (this._psWaiters) {
           for (const w of this._psWaiters.values()) {
             clearTimeout(w.timer);
-            w.resolve(false);
+            w.resolve("failed");
           }
           this._psWaiters.clear();
         }
@@ -159,14 +162,18 @@ class ClipboardManager {
     }
   }
 
-  // 送出指令並等待常駐 PS 回報 <<TU:token:OK|ERR>>；逾時或寫入失敗回傳 false。
+  // 送出指令並等待常駐 PS 回報 <<TU:token:OK|ERR>>。回傳狀態字串：
+  //   "ok"       → 確認完成（全部字元送出，或已貼上）
+  //   "err"      → 已嘗試但可能只完成一半（上層不可再 Ctrl+V，避免重複輸入）
+  //   "timeout"  → 逾時未回報；指令可能仍在 PS 端跑（同樣不可再 Ctrl+V）
+  //   "not-sent" → 指令根本沒送出（PS 未就緒/寫入失敗）→ 什麼都沒發生，上層可安全回退
   _psSendAndWait(line, token, timeoutMs) {
     return new Promise((resolve) => {
-      if (!this._psShell || !this._psReady) return resolve(false);
+      if (!this._psShell || !this._psReady) return resolve("not-sent");
       this._psWaiters = this._psWaiters || new Map();
       const timer = setTimeout(() => {
         this._psWaiters.delete(token);
-        resolve(false);
+        resolve("timeout");
       }, timeoutMs);
       this._psWaiters.set(token, { resolve, timer });
       try {
@@ -176,7 +183,7 @@ class ClipboardManager {
         this._psWaiters.delete(token);
         this.safeLog(`⚠️ 寫入常駐 PS 失敗: ${e.message}`);
         this._psReady = false;
-        resolve(false);
+        resolve("not-sent");
       }
     });
   }
@@ -299,11 +306,11 @@ class ClipboardManager {
   //   主控台（cmd/PowerShell/Terminal）→ SendInput + KEYEVENTF_UNICODE 逐字打字
   //     （這類視窗不接受 SendKeys 貼上，逐字打字是唯一能輸入的方式）
   //   一般視窗 → 維持原本的 SendKeys('^v') 快速貼上（長文比逐字打字快，保留作者原設計）
-  // 兩條路都會回報 <<TU:token:OK|ERR>>，等到確認才回傳；逾時或失敗回傳 false 讓上層回退。
+  // 回傳 _psSendAndWait 的狀態字串："ok"/"err"/"timeout"/"not-sent"（語意見該函式）。
   async focusAndSmartInput(text, mode = "auto") {
-    if (process.platform !== "win32") return false;
+    if (process.platform !== "win32") return "not-sent";
     const ps = this._ensurePsShell();
-    if (!ps) return false;
+    if (!ps) return "not-sent";
     const b64 = Buffer.from(String(text), "utf8").toString("base64");
     const token = "t" + Date.now().toString(36) + Math.floor(Math.random() * 1e9).toString(36);
     // mode 只可能是 auto/type/paste（來自設定白名單，非使用者自由輸入），可安全內嵌
@@ -393,7 +400,8 @@ class ClipboardManager {
 
   async pasteText(text, opts = {}) {
     try {
-      this.safeLog("🎯 pasteText:", text?.substring(0, 30));
+      // 只記長度，不記內容（辨識文字可能含隱私）
+      this.safeLog("🎯 pasteText:", text ? `${text.length} 字` : "(空)");
       // 主控台輸入方式（來自設定）：auto（偵測主控台自動切換）/ type（一律逐字打字）/ paste（一律貼上）
       const consoleInputMode = opts.consoleInputMode || "auto";
 
@@ -402,16 +410,23 @@ class ClipboardManager {
         const originalClipboard = clipboard.readText();
         clipboard.writeText(text);
 
-        // 優先用常駐 PowerShell 快速還原焦點 + 依設定選擇輸入方式（type/paste/auto）；
-        // 失敗才回退純 Ctrl+V。
-        if (await this.focusAndSmartInput(text, consoleInputMode)) {
-          this.safeLog(`⚡ 快速輸入 (常駐 PS, 模式=${consoleInputMode})`);
-        } else if (this.focusAndPasteFast()) {
-          this.safeLog("⚡ 快速貼上 (常駐 PS, 還原焦點 + Ctrl+V)");
+        // 常駐 PowerShell 還原焦點 + 依設定選擇輸入方式（type/paste/auto）。
+        const status = await this.focusAndSmartInput(text, consoleInputMode);
+        if (status === "ok") {
+          this.safeLog(`⚡ 快速輸入完成 (模式=${consoleInputMode})`);
+        } else if (status === "not-sent") {
+          // 指令根本沒送出（常駐 PS 未就緒）→ 什麼都沒發生，安全回退 Ctrl+V。
+          if (this.focusAndPasteFast()) {
+            this.safeLog("⚡ 快速貼上 (回退 Ctrl+V)");
+          } else {
+            // 回退：舊的 spawn 方式（每次 Add-Type，較慢）
+            this.safeLog("⌨️ 嘗試自動貼上 (SendKeys 回退)");
+            await this.pasteWindows();
+          }
         } else {
-          // 回退：舊的 spawn 方式（每次 Add-Type，較慢）
-          this.safeLog("⌨️ 嘗試自動貼上 (SendKeys 回退)");
-          await this.pasteWindows();
+          // "err"/"timeout"/"failed"：逐字打字已送出但未確認成功，可能已打了一半 →
+          // 不再自動 Ctrl+V（避免和已輸入的字重複）；文字已在剪貼簿，可手動貼上。
+          this.safeLog(`⚠️ 輸入未確認完成（${status}），文字已在剪貼簿，可手動 Ctrl+V`);
         }
 
         // 等貼上完成後還原原本的剪貼簿內容（給足 Ctrl+V 讀取的時間）

--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -85,6 +85,10 @@ class ClipboardManager {
         `Add-Type -Namespace Native -Name Fg -MemberDefinition '[DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow(); [DllImport("user32.dll")][return: MarshalAs(UnmanagedType.Bool)] public static extern bool SetForegroundWindow(IntPtr hWnd); [DllImport("user32.dll")] public static extern bool AttachThreadInput(uint a, uint b, bool c); [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, IntPtr p); [DllImport("kernel32.dll")] public static extern uint GetCurrentThreadId();'`,
         `$ws = New-Object -ComObject WScript.Shell`,
         `function Restore-Fg { param($hwnd) $ft=[Native.Fg]::GetWindowThreadProcessId($hwnd,[IntPtr]::Zero); $ct=[Native.Fg]::GetCurrentThreadId(); if($ft -ne $ct){[Native.Fg]::AttachThreadInput($ct,$ft,$true)|Out-Null}; [Native.Fg]::SetForegroundWindow($hwnd)|Out-Null; if($ft -ne $ct){[Native.Fg]::AttachThreadInput($ct,$ft,$false)|Out-Null} }`,
+        // SendInput + KEYEVENTF_UNICODE 逐字打字：主控台（cmd / PowerShell）等
+        // 不接受 SendKeys 貼上的視窗也能正確輸入文字。
+        `Add-Type -TypeDefinition 'using System; using System.Runtime.InteropServices; public class Uni { [StructLayout(LayoutKind.Sequential)] public struct INPUT { public int type; public InputUnion u; } [StructLayout(LayoutKind.Explicit)] public struct InputUnion { [FieldOffset(0)] public KEYBDINPUT ki; [FieldOffset(0)] public MOUSEINPUT mi; } [StructLayout(LayoutKind.Sequential)] public struct KEYBDINPUT { public ushort wVk; public ushort wScan; public uint dwFlags; public uint time; public IntPtr dwExtraInfo; } [StructLayout(LayoutKind.Sequential)] public struct MOUSEINPUT { public int dx; public int dy; public uint mouseData; public uint dwFlags; public uint time; public IntPtr dwExtraInfo; } [DllImport("user32.dll")] public static extern uint SendInput(uint n, INPUT[] p, int size); public static void TypeString(string s) { foreach (char c in s) { INPUT[] a = new INPUT[2]; a[0].type = 1; a[0].u.ki.wScan = (ushort)c; a[0].u.ki.dwFlags = 4; a[1].type = 1; a[1].u.ki.wScan = (ushort)c; a[1].u.ki.dwFlags = 6; SendInput(2, a, Marshal.SizeOf(typeof(INPUT))); } } }'`,
+        `function Type-Uni { param($b64) $t=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($b64)); [Uni]::TypeString($t) }`,
         `$savedHwnd = [IntPtr]::Zero`,
       ];
       for (const line of init) ps.stdin.write(line + "\r\n");
@@ -225,6 +229,19 @@ class ClipboardManager {
     );
   }
 
+  // 快速：還原焦點到先前視窗並「逐字打字」（SendInput + KEYEVENTF_UNICODE）
+  // 相較於 SendKeys('^v')，逐字打字模擬真實鍵盤輸入，可正確輸入到
+  // cmd / PowerShell 等主控台視窗（這類視窗不接受 SendKeys 貼上）。
+  focusAndTypeUnicode(text) {
+    if (process.platform !== "win32") return false;
+    const ps = this._ensurePsShell();
+    if (!ps) return false;
+    const b64 = Buffer.from(String(text), "utf8").toString("base64");
+    return this._psSend(
+      `if ($savedHwnd -ne [IntPtr]::Zero) { Restore-Fg $savedHwnd; Start-Sleep -Milliseconds 25 }; Type-Uni '${b64}'`
+    );
+  }
+
   // 快速：還原焦點到先前視窗並複製選取（Ctrl+C）—— 操作模式抓選取用
   focusAndCopyFast() {
     if (process.platform === "linux") return this._xdoKeys(["ctrl+c"]);
@@ -312,8 +329,11 @@ class ClipboardManager {
         const originalClipboard = clipboard.readText();
         clipboard.writeText(text);
 
-        // 優先用常駐 PowerShell 快速還原焦點 + 貼上（~0.1 秒）
-        if (this.focusAndPasteFast()) {
+        // 優先用常駐 PowerShell 快速還原焦點 + 逐字打字（Unicode，
+        // cmd / PowerShell 等主控台視窗也能輸入）；失敗才回退 Ctrl+V。
+        if (this.focusAndTypeUnicode(text)) {
+          this.safeLog("⚡ 快速輸入 (常駐 PS, 還原焦點 + Unicode 逐字打字)");
+        } else if (this.focusAndPasteFast()) {
           this.safeLog("⚡ 快速貼上 (常駐 PS, 還原焦點 + Ctrl+V)");
         } else {
           // 回退：舊的 spawn 方式（每次 Add-Type，較慢）

--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -67,7 +67,7 @@ class ClipboardManager {
       this._psReady = false;
 
       // 讀取常駐 PS 的 stdout，解析「打字完成」回報標記 <<TU:token:OK|ERR>>，
-      // 讓 focusAndTypeUnicode 能等到「確認全部字元送出」才回報成功。
+      // 讓 focusAndSmartInput 能等到「確認全部字元送出/貼上」才回報成功。
       this._psWaiters = this._psWaiters || new Map();
       let psBuf = "";
       ps.stdout.on("data", (chunk) => {
@@ -116,7 +116,9 @@ class ClipboardManager {
 
       // 一次性初始化：載入 Win32 API + WScript.Shell COM + 還原焦點函式
       const init = [
-        `Add-Type -Namespace Native -Name Fg -MemberDefinition '[DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow(); [DllImport("user32.dll")][return: MarshalAs(UnmanagedType.Bool)] public static extern bool SetForegroundWindow(IntPtr hWnd); [DllImport("user32.dll")] public static extern bool AttachThreadInput(uint a, uint b, bool c); [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, IntPtr p); [DllImport("kernel32.dll")] public static extern uint GetCurrentThreadId();'`,
+        // IsConsoleWindow：用視窗類別判斷目標是不是主控台（cmd/PowerShell=ConsoleWindowClass、
+        // Windows Terminal=CASCADIA_HOSTING_WINDOW_CLASS），決定用「逐字打字」還是「快速貼上」。
+        `Add-Type -Namespace Native -Name Fg -MemberDefinition '[DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow(); [DllImport("user32.dll")][return: MarshalAs(UnmanagedType.Bool)] public static extern bool SetForegroundWindow(IntPtr hWnd); [DllImport("user32.dll")] public static extern bool AttachThreadInput(uint a, uint b, bool c); [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, IntPtr p); [DllImport("kernel32.dll")] public static extern uint GetCurrentThreadId(); [DllImport("user32.dll", CharSet = CharSet.Unicode)] public static extern int GetClassName(IntPtr hWnd, System.Text.StringBuilder lpClassName, int nMaxCount); public static bool IsConsoleWindow(IntPtr h) { if (h == IntPtr.Zero) return false; System.Text.StringBuilder sb = new System.Text.StringBuilder(256); GetClassName(h, sb, 256); string c = sb.ToString(); return c == "ConsoleWindowClass" || c == "CASCADIA_HOSTING_WINDOW_CLASS"; }'`,
         `$ws = New-Object -ComObject WScript.Shell`,
         `function Restore-Fg { param($hwnd) $ft=[Native.Fg]::GetWindowThreadProcessId($hwnd,[IntPtr]::Zero); $ct=[Native.Fg]::GetCurrentThreadId(); if($ft -ne $ct){[Native.Fg]::AttachThreadInput($ct,$ft,$true)|Out-Null}; [Native.Fg]::SetForegroundWindow($hwnd)|Out-Null; if($ft -ne $ct){[Native.Fg]::AttachThreadInput($ct,$ft,$false)|Out-Null} }`,
         // SendInput + KEYEVENTF_UNICODE 逐字打字：主控台（cmd / PowerShell）等
@@ -125,6 +127,10 @@ class ClipboardManager {
         // 逐字打字並「確認全部字元都送出」：SendInput 回傳實際插入的事件數，
         // 與預期（字元數 x 2）比對；相符才回報 OK，否則 ERR（讓上層回退 Ctrl+V）。
         `function Type-Uni { param($b64,$tok) try { $t=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($b64)); $exp=[uint32]($t.Length*2); $got=[Uni]::TypeString($t); if($got -eq $exp -and $exp -gt 0){ Write-Output ('<<TU:'+$tok+':OK>>') } else { Write-Output ('<<TU:'+$tok+':ERR>>') } } catch { Write-Output ('<<TU:'+$tok+':ERR>>') } }`,
+        // 依目標視窗自動選擇輸入方式：還原焦點後，主控台視窗用「逐字打字」（唯一能輸入
+        // 進 cmd/PowerShell 的方式），一般視窗維持原本的「Ctrl+V 快速貼上」（長文比逐字打字快，
+        // 保留作者原設計）。兩條路都回報同一個 <<TU:token:OK|ERR>> 標記，上層等同確認。
+        `function Smart-Input { param($b64,$tok) try { if ($savedHwnd -ne [IntPtr]::Zero) { Restore-Fg $savedHwnd; Start-Sleep -Milliseconds 25 }; if ([Native.Fg]::IsConsoleWindow($savedHwnd)) { Type-Uni $b64 $tok } else { $ws.SendKeys('^v'); Write-Output ('<<TU:'+$tok+':OK>>') } } catch { Write-Output ('<<TU:'+$tok+':ERR>>') } }`,
         `$savedHwnd = [IntPtr]::Zero`,
       ];
       for (const line of init) ps.stdin.write(line + "\r\n");
@@ -287,23 +293,20 @@ class ClipboardManager {
     );
   }
 
-  // 快速：還原焦點到先前視窗並「逐字打字」（SendInput + KEYEVENTF_UNICODE）
-  // 相較於 SendKeys('^v')，逐字打字模擬真實鍵盤輸入，可正確輸入到
-  // cmd / PowerShell 等主控台視窗（這類視窗不接受 SendKeys 貼上）。
-  async focusAndTypeUnicode(text) {
+  // 快速：還原焦點到先前視窗，並依「目標是不是主控台」自動選擇輸入方式：
+  //   主控台（cmd/PowerShell/Terminal）→ SendInput + KEYEVENTF_UNICODE 逐字打字
+  //     （這類視窗不接受 SendKeys 貼上，逐字打字是唯一能輸入的方式）
+  //   一般視窗 → 維持原本的 SendKeys('^v') 快速貼上（長文比逐字打字快，保留作者原設計）
+  // 兩條路都會回報 <<TU:token:OK|ERR>>，等到確認才回傳；逾時或失敗回傳 false 讓上層回退。
+  async focusAndSmartInput(text) {
     if (process.platform !== "win32") return false;
     const ps = this._ensurePsShell();
     if (!ps) return false;
     const b64 = Buffer.from(String(text), "utf8").toString("base64");
     const token = "t" + Date.now().toString(36) + Math.floor(Math.random() * 1e9).toString(36);
-    // 等待 PS 回報「已確認全部字元送出」；逾時或失敗回傳 false，
-    // 讓上層改用 Ctrl+V，避免「回報成功但實際沒輸入」的情況。
+    // 逐字打字這條路較久，逾時時間隨長度放寬；貼上那條會很快回報。
     const timeoutMs = Math.min(8000, 800 + String(text).length * 20);
-    return this._psSendAndWait(
-      `if ($savedHwnd -ne [IntPtr]::Zero) { Restore-Fg $savedHwnd; Start-Sleep -Milliseconds 25 }; Type-Uni '${b64}' '${token}'`,
-      token,
-      timeoutMs
-    );
+    return this._psSendAndWait(`Smart-Input '${b64}' '${token}'`, token, timeoutMs);
   }
 
   // 快速：還原焦點到先前視窗並複製選取（Ctrl+C）—— 操作模式抓選取用
@@ -393,10 +396,10 @@ class ClipboardManager {
         const originalClipboard = clipboard.readText();
         clipboard.writeText(text);
 
-        // 優先用常駐 PowerShell 快速還原焦點 + 逐字打字（Unicode，
-        // cmd / PowerShell 等主控台視窗也能輸入）；失敗才回退 Ctrl+V。
-        if (await this.focusAndTypeUnicode(text)) {
-          this.safeLog("⚡ 快速輸入 (常駐 PS, 還原焦點 + Unicode 逐字打字)");
+        // 優先用常駐 PowerShell 快速還原焦點 + 自動選擇輸入方式（主控台逐字打字、
+        // 一般視窗 Ctrl+V 貼上）；失敗才回退純 Ctrl+V。
+        if (await this.focusAndSmartInput(text)) {
+          this.safeLog("⚡ 快速輸入 (常駐 PS: 主控台→Unicode 逐字打字 / 一般視窗→Ctrl+V)");
         } else if (this.focusAndPasteFast()) {
           this.safeLog("⚡ 快速貼上 (常駐 PS, 還原焦點 + Ctrl+V)");
         } else {

--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -91,12 +91,26 @@ class ClipboardManager {
         this.safeLog(`⚠️ PS 常駐錯誤: ${d.toString().slice(0, 200)}`);
       });
       const cleanup = () => {
+        // 清掉所有還在等回報的 waiter（清 timer + resolve(false) + 清空 map），
+        // 避免 PS 結束/出錯時有 Promise 卡到各自的 timeout 才 fallback。
+        if (this._psWaiters) {
+          for (const w of this._psWaiters.values()) {
+            clearTimeout(w.timer);
+            w.resolve(false);
+          }
+          this._psWaiters.clear();
+        }
         this._psShell = null;
         this._psReady = false;
       };
       ps.on("exit", cleanup);
       ps.on("error", (e) => {
         this.safeLog(`❌ PS 常駐程序錯誤: ${e.message}`);
+        cleanup();
+      });
+      // stdin 錯誤（如 EPIPE）需自行處理，否則未捕捉的 error 事件可能導致程式崩潰。
+      ps.stdin.on("error", (e) => {
+        this.safeLog(`⚠️ PS stdin 錯誤: ${e.message}`);
         cleanup();
       });
 

--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -66,7 +66,27 @@ class ClipboardManager {
       this._psShell = ps;
       this._psReady = false;
 
-      ps.stdout.on("data", () => {}); // 排空，避免 buffer 塞滿
+      // 讀取常駐 PS 的 stdout，解析「打字完成」回報標記 <<TU:token:OK|ERR>>，
+      // 讓 focusAndTypeUnicode 能等到「確認全部字元送出」才回報成功。
+      this._psWaiters = this._psWaiters || new Map();
+      let psBuf = "";
+      ps.stdout.on("data", (chunk) => {
+        psBuf += chunk.toString();
+        let idx;
+        while ((idx = psBuf.indexOf("\n")) >= 0) {
+          const line = psBuf.slice(0, idx).trim();
+          psBuf = psBuf.slice(idx + 1);
+          const m = line.match(/<<TU:([0-9a-z]+):(OK|ERR)>>/);
+          if (m) {
+            const w = this._psWaiters.get(m[1]);
+            if (w) {
+              this._psWaiters.delete(m[1]);
+              clearTimeout(w.timer);
+              w.resolve(m[2] === "OK");
+            }
+          }
+        }
+      });
       ps.stderr.on("data", (d) => {
         this.safeLog(`⚠️ PS 常駐錯誤: ${d.toString().slice(0, 200)}`);
       });
@@ -87,8 +107,10 @@ class ClipboardManager {
         `function Restore-Fg { param($hwnd) $ft=[Native.Fg]::GetWindowThreadProcessId($hwnd,[IntPtr]::Zero); $ct=[Native.Fg]::GetCurrentThreadId(); if($ft -ne $ct){[Native.Fg]::AttachThreadInput($ct,$ft,$true)|Out-Null}; [Native.Fg]::SetForegroundWindow($hwnd)|Out-Null; if($ft -ne $ct){[Native.Fg]::AttachThreadInput($ct,$ft,$false)|Out-Null} }`,
         // SendInput + KEYEVENTF_UNICODE 逐字打字：主控台（cmd / PowerShell）等
         // 不接受 SendKeys 貼上的視窗也能正確輸入文字。
-        `Add-Type -TypeDefinition 'using System; using System.Runtime.InteropServices; public class Uni { [StructLayout(LayoutKind.Sequential)] public struct INPUT { public int type; public InputUnion u; } [StructLayout(LayoutKind.Explicit)] public struct InputUnion { [FieldOffset(0)] public KEYBDINPUT ki; [FieldOffset(0)] public MOUSEINPUT mi; } [StructLayout(LayoutKind.Sequential)] public struct KEYBDINPUT { public ushort wVk; public ushort wScan; public uint dwFlags; public uint time; public IntPtr dwExtraInfo; } [StructLayout(LayoutKind.Sequential)] public struct MOUSEINPUT { public int dx; public int dy; public uint mouseData; public uint dwFlags; public uint time; public IntPtr dwExtraInfo; } [DllImport("user32.dll")] public static extern uint SendInput(uint n, INPUT[] p, int size); public static void TypeString(string s) { foreach (char c in s) { INPUT[] a = new INPUT[2]; a[0].type = 1; a[0].u.ki.wScan = (ushort)c; a[0].u.ki.dwFlags = 4; a[1].type = 1; a[1].u.ki.wScan = (ushort)c; a[1].u.ki.dwFlags = 6; SendInput(2, a, Marshal.SizeOf(typeof(INPUT))); } } }'`,
-        `function Type-Uni { param($b64) $t=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($b64)); [Uni]::TypeString($t) }`,
+        `Add-Type -TypeDefinition 'using System; using System.Runtime.InteropServices; public class Uni { [StructLayout(LayoutKind.Sequential)] public struct INPUT { public int type; public InputUnion u; } [StructLayout(LayoutKind.Explicit)] public struct InputUnion { [FieldOffset(0)] public KEYBDINPUT ki; [FieldOffset(0)] public MOUSEINPUT mi; } [StructLayout(LayoutKind.Sequential)] public struct KEYBDINPUT { public ushort wVk; public ushort wScan; public uint dwFlags; public uint time; public IntPtr dwExtraInfo; } [StructLayout(LayoutKind.Sequential)] public struct MOUSEINPUT { public int dx; public int dy; public uint mouseData; public uint dwFlags; public uint time; public IntPtr dwExtraInfo; } [DllImport("user32.dll")] public static extern uint SendInput(uint n, INPUT[] p, int size); public static uint TypeString(string s) { uint total = 0; foreach (char c in s) { INPUT[] a = new INPUT[2]; a[0].type = 1; a[0].u.ki.wScan = (ushort)c; a[0].u.ki.dwFlags = 4; a[1].type = 1; a[1].u.ki.wScan = (ushort)c; a[1].u.ki.dwFlags = 6; total += SendInput(2, a, Marshal.SizeOf(typeof(INPUT))); } return total; } }'`,
+        // 逐字打字並「確認全部字元都送出」：SendInput 回傳實際插入的事件數，
+        // 與預期（字元數 x 2）比對；相符才回報 OK，否則 ERR（讓上層回退 Ctrl+V）。
+        `function Type-Uni { param($b64,$tok) try { $t=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($b64)); $exp=[uint32]($t.Length*2); $got=[Uni]::TypeString($t); if($got -eq $exp -and $exp -gt 0){ Write-Output ('<<TU:'+$tok+':OK>>') } else { Write-Output ('<<TU:'+$tok+':ERR>>') } } catch { Write-Output ('<<TU:'+$tok+':ERR>>') } }`,
         `$savedHwnd = [IntPtr]::Zero`,
       ];
       for (const line of init) ps.stdin.write(line + "\r\n");
@@ -113,6 +135,28 @@ class ClipboardManager {
       this._psReady = false;
       return false;
     }
+  }
+
+  // 送出指令並等待常駐 PS 回報 <<TU:token:OK|ERR>>；逾時或寫入失敗回傳 false。
+  _psSendAndWait(line, token, timeoutMs) {
+    return new Promise((resolve) => {
+      if (!this._psShell || !this._psReady) return resolve(false);
+      this._psWaiters = this._psWaiters || new Map();
+      const timer = setTimeout(() => {
+        this._psWaiters.delete(token);
+        resolve(false);
+      }, timeoutMs);
+      this._psWaiters.set(token, { resolve, timer });
+      try {
+        this._psShell.stdin.write(line + "\r\n");
+      } catch (e) {
+        clearTimeout(timer);
+        this._psWaiters.delete(token);
+        this.safeLog(`⚠️ 寫入常駐 PS 失敗: ${e.message}`);
+        this._psReady = false;
+        resolve(false);
+      }
+    });
   }
 
   // ===== Linux：用 xdotool 做等效的「擷取前景視窗 / 還原焦點 / 送鍵」 =====
@@ -232,13 +276,19 @@ class ClipboardManager {
   // 快速：還原焦點到先前視窗並「逐字打字」（SendInput + KEYEVENTF_UNICODE）
   // 相較於 SendKeys('^v')，逐字打字模擬真實鍵盤輸入，可正確輸入到
   // cmd / PowerShell 等主控台視窗（這類視窗不接受 SendKeys 貼上）。
-  focusAndTypeUnicode(text) {
+  async focusAndTypeUnicode(text) {
     if (process.platform !== "win32") return false;
     const ps = this._ensurePsShell();
     if (!ps) return false;
     const b64 = Buffer.from(String(text), "utf8").toString("base64");
-    return this._psSend(
-      `if ($savedHwnd -ne [IntPtr]::Zero) { Restore-Fg $savedHwnd; Start-Sleep -Milliseconds 25 }; Type-Uni '${b64}'`
+    const token = "t" + Date.now().toString(36) + Math.floor(Math.random() * 1e9).toString(36);
+    // 等待 PS 回報「已確認全部字元送出」；逾時或失敗回傳 false，
+    // 讓上層改用 Ctrl+V，避免「回報成功但實際沒輸入」的情況。
+    const timeoutMs = Math.min(8000, 800 + String(text).length * 20);
+    return this._psSendAndWait(
+      `if ($savedHwnd -ne [IntPtr]::Zero) { Restore-Fg $savedHwnd; Start-Sleep -Milliseconds 25 }; Type-Uni '${b64}' '${token}'`,
+      token,
+      timeoutMs
     );
   }
 
@@ -331,7 +381,7 @@ class ClipboardManager {
 
         // 優先用常駐 PowerShell 快速還原焦點 + 逐字打字（Unicode，
         // cmd / PowerShell 等主控台視窗也能輸入）；失敗才回退 Ctrl+V。
-        if (this.focusAndTypeUnicode(text)) {
+        if (await this.focusAndTypeUnicode(text)) {
           this.safeLog("⚡ 快速輸入 (常駐 PS, 還原焦點 + Unicode 逐字打字)");
         } else if (this.focusAndPasteFast()) {
           this.safeLog("⚡ 快速貼上 (常駐 PS, 還原焦點 + Ctrl+V)");

--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -127,10 +127,12 @@ class ClipboardManager {
         // 逐字打字並「確認全部字元都送出」：SendInput 回傳實際插入的事件數，
         // 與預期（字元數 x 2）比對；相符才回報 OK，否則 ERR（讓上層回退 Ctrl+V）。
         `function Type-Uni { param($b64,$tok) try { $t=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($b64)); $exp=[uint32]($t.Length*2); $got=[Uni]::TypeString($t); if($got -eq $exp -and $exp -gt 0){ Write-Output ('<<TU:'+$tok+':OK>>') } else { Write-Output ('<<TU:'+$tok+':ERR>>') } } catch { Write-Output ('<<TU:'+$tok+':ERR>>') } }`,
-        // 依目標視窗自動選擇輸入方式：還原焦點後，主控台視窗用「逐字打字」（唯一能輸入
-        // 進 cmd/PowerShell 的方式），一般視窗維持原本的「Ctrl+V 快速貼上」（長文比逐字打字快，
-        // 保留作者原設計）。兩條路都回報同一個 <<TU:token:OK|ERR>> 標記，上層等同確認。
-        `function Smart-Input { param($b64,$tok) try { if ($savedHwnd -ne [IntPtr]::Zero) { Restore-Fg $savedHwnd; Start-Sleep -Milliseconds 25 }; if ([Native.Fg]::IsConsoleWindow($savedHwnd)) { Type-Uni $b64 $tok } else { $ws.SendKeys('^v'); Write-Output ('<<TU:'+$tok+':OK>>') } } catch { Write-Output ('<<TU:'+$tok+':ERR>>') } }`,
+        // 依「主控台輸入方式」設定 $mode 選擇輸入法（還原焦點後）：
+        //   'type'  → 一律逐字打字（SendInput Unicode，什麼視窗都能進，含 cmd）
+        //   'paste' → 一律 Ctrl+V 貼上（原版行為，長文最快）
+        //   其他/'auto' → 偵測目標視窗：主控台逐字打字、一般視窗貼上（預設）
+        // 三條路都回報同一個 <<TU:token:OK|ERR>> 標記，上層等同確認。
+        `function Smart-Input { param($b64,$tok,$mode) try { if ($savedHwnd -ne [IntPtr]::Zero) { Restore-Fg $savedHwnd; Start-Sleep -Milliseconds 25 }; if ($mode -eq 'type') { $useType = $true } elseif ($mode -eq 'paste') { $useType = $false } else { $useType = [Native.Fg]::IsConsoleWindow($savedHwnd) }; if ($useType) { Type-Uni $b64 $tok } else { $ws.SendKeys('^v'); Write-Output ('<<TU:'+$tok+':OK>>') } } catch { Write-Output ('<<TU:'+$tok+':ERR>>') } }`,
         `$savedHwnd = [IntPtr]::Zero`,
       ];
       for (const line of init) ps.stdin.write(line + "\r\n");
@@ -298,15 +300,17 @@ class ClipboardManager {
   //     （這類視窗不接受 SendKeys 貼上，逐字打字是唯一能輸入的方式）
   //   一般視窗 → 維持原本的 SendKeys('^v') 快速貼上（長文比逐字打字快，保留作者原設計）
   // 兩條路都會回報 <<TU:token:OK|ERR>>，等到確認才回傳；逾時或失敗回傳 false 讓上層回退。
-  async focusAndSmartInput(text) {
+  async focusAndSmartInput(text, mode = "auto") {
     if (process.platform !== "win32") return false;
     const ps = this._ensurePsShell();
     if (!ps) return false;
     const b64 = Buffer.from(String(text), "utf8").toString("base64");
     const token = "t" + Date.now().toString(36) + Math.floor(Math.random() * 1e9).toString(36);
+    // mode 只可能是 auto/type/paste（來自設定白名單，非使用者自由輸入），可安全內嵌
+    const m = mode === "type" || mode === "paste" ? mode : "auto";
     // 逐字打字這條路較久，逾時時間隨長度放寬；貼上那條會很快回報。
     const timeoutMs = Math.min(8000, 800 + String(text).length * 20);
-    return this._psSendAndWait(`Smart-Input '${b64}' '${token}'`, token, timeoutMs);
+    return this._psSendAndWait(`Smart-Input '${b64}' '${token}' '${m}'`, token, timeoutMs);
   }
 
   // 快速：還原焦點到先前視窗並複製選取（Ctrl+C）—— 操作模式抓選取用
@@ -387,19 +391,21 @@ class ClipboardManager {
     return await this.pasteText(text);
   }
 
-  async pasteText(text) {
+  async pasteText(text, opts = {}) {
     try {
       this.safeLog("🎯 pasteText:", text?.substring(0, 30));
+      // 主控台輸入方式（來自設定）：auto（偵測主控台自動切換）/ type（一律逐字打字）/ paste（一律貼上）
+      const consoleInputMode = opts.consoleInputMode || "auto";
 
       if (process.platform === "win32") {
         // 先保存使用者原本的剪貼簿，貼上後再還原，避免覆蓋掉他複製的東西
         const originalClipboard = clipboard.readText();
         clipboard.writeText(text);
 
-        // 優先用常駐 PowerShell 快速還原焦點 + 自動選擇輸入方式（主控台逐字打字、
-        // 一般視窗 Ctrl+V 貼上）；失敗才回退純 Ctrl+V。
-        if (await this.focusAndSmartInput(text)) {
-          this.safeLog("⚡ 快速輸入 (常駐 PS: 主控台→Unicode 逐字打字 / 一般視窗→Ctrl+V)");
+        // 優先用常駐 PowerShell 快速還原焦點 + 依設定選擇輸入方式（type/paste/auto）；
+        // 失敗才回退純 Ctrl+V。
+        if (await this.focusAndSmartInput(text, consoleInputMode)) {
+          this.safeLog(`⚡ 快速輸入 (常駐 PS, 模式=${consoleInputMode})`);
         } else if (this.focusAndPasteFast()) {
           this.safeLog("⚡ 快速貼上 (常駐 PS, 還原焦點 + Ctrl+V)");
         } else {

--- a/src/helpers/ipc/window.js
+++ b/src/helpers/ipc/window.js
@@ -11,11 +11,14 @@ module.exports = function register(ctx) {
     }
   });
 
+  // 「主控台輸入方式」的唯一合法值白名單：auto（偵測自動切換）/ type（一律逐字打字）/ paste（一律貼上）
+  const CONSOLE_INPUT_MODES = ["auto", "type", "paste"];
   ipcMain.handle("paste-text", async (event, text) => {
-    // 讀「主控台輸入方式」設定：auto（預設，偵測主控台自動切換）/ type（一律逐字打字）/ paste（一律貼上）
+    // 讀設定並以白名單收斂：非合法值一律當 auto，避免把任意值往下傳
     let consoleInputMode = "auto";
     try {
-      consoleInputMode = ctx.databaseManager?.getSetting?.("console_input_method", "auto") || "auto";
+      const v = ctx.databaseManager?.getSetting?.("console_input_method", "auto");
+      consoleInputMode = CONSOLE_INPUT_MODES.includes(v) ? v : "auto";
     } catch (e) { /* 讀取失敗就用預設 auto */ }
     return ctx.clipboardManager.pasteText(text, { consoleInputMode });
   });

--- a/src/helpers/ipc/window.js
+++ b/src/helpers/ipc/window.js
@@ -12,7 +12,12 @@ module.exports = function register(ctx) {
   });
 
   ipcMain.handle("paste-text", async (event, text) => {
-    return ctx.clipboardManager.pasteText(text);
+    // 讀「主控台輸入方式」設定：auto（預設，偵測主控台自動切換）/ type（一律逐字打字）/ paste（一律貼上）
+    let consoleInputMode = "auto";
+    try {
+      consoleInputMode = ctx.databaseManager?.getSetting?.("console_input_method", "auto") || "auto";
+    } catch (e) { /* 讀取失敗就用預設 auto */ }
+    return ctx.clipboardManager.pasteText(text, { consoleInputMode });
   });
 
   // 發送 Enter 鍵（完全信任模式）

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -65,6 +65,11 @@ export default {
     asrProfileStandard: 'Standard (most accurate)',
     asrProfileFast: 'Fast (older machines)',
     asrProfileChanged: 'Performance mode changed, applies to the next recognition',
+    consoleInputMethod: 'Console input method',
+    consoleInputMethodDesc: 'Consoles (cmd / PowerShell) reject paste; typing char-by-char is required to input there',
+    consoleInputAuto: 'Auto (type in consoles, paste elsewhere)',
+    consoleInputType: 'Always type',
+    consoleInputPaste: 'Always paste (original)',
     convertTranscription: 'Convert Transcription',
     convertTranscriptionDesc: 'Convert speech recognition results to the current language',
 

--- a/src/i18n/zh-CN.js
+++ b/src/i18n/zh-CN.js
@@ -65,6 +65,11 @@ export default {
     asrProfileStandard: '标准（最准）',
     asrProfileFast: '快速（弱电脑）',
     asrProfileChanged: '性能模式已切换，下次识别生效',
+    consoleInputMethod: '控制台输入方式',
+    consoleInputMethodDesc: 'cmd / PowerShell 等控制台不接受「粘贴」，需逐字打字才能输入',
+    consoleInputAuto: '自动（控制台逐字、其他粘贴）',
+    consoleInputType: '一律逐字打字',
+    consoleInputPaste: '一律粘贴（原版）',
     convertTranscription: '转换识别结果',
     convertTranscriptionDesc: '将语音识别结果转换为当前语言',
 

--- a/src/i18n/zh-TW.js
+++ b/src/i18n/zh-TW.js
@@ -65,6 +65,11 @@ export default {
     asrProfileStandard: '標準（最準）',
     asrProfileFast: '快速（弱電腦）',
     asrProfileChanged: '效能模式已切換，下次辨識生效',
+    consoleInputMethod: '主控台輸入方式',
+    consoleInputMethodDesc: 'cmd / PowerShell 等主控台不接受「貼上」，需逐字打字才進得去',
+    consoleInputAuto: '自動（主控台逐字、其他貼上）',
+    consoleInputType: '一律逐字打字',
+    consoleInputPaste: '一律貼上（原版）',
     convertTranscription: '轉換辨識結果',
     convertTranscriptionDesc: '將語音辨識結果轉換為當前語言',
 

--- a/src/settings.jsx
+++ b/src/settings.jsx
@@ -25,6 +25,9 @@ const SETTINGS_TABS = [
   { id: 'about', labelKey: 'settings.tabs.about', icon: Info },
 ];
 
+// 是否 Windows：「主控台輸入方式」只影響 Windows 的貼上/打字，非 Windows 隱藏該設定
+const IS_WINDOWS = typeof navigator !== "undefined" && /Windows/i.test(navigator.userAgent);
+
 const SettingsPage = () => {
   const { t, language, setLanguage, languages } = useTranslation();
   const [activeTab, setActiveTab] = useState('general');
@@ -930,7 +933,8 @@ const SettingsPage = () => {
                   </select>
                 </div>
 
-                {/* 主控台輸入方式：自動 / 一律逐字打字 / 一律貼上 */}
+                {/* 主控台輸入方式：自動 / 一律逐字打字 / 一律貼上（僅 Windows 有作用，故僅 Windows 顯示） */}
+                {IS_WINDOWS && (
                 <div className="flex items-center justify-between">
                   <div>
                     <label className="text-sm font-medium text-gray-800 dark:text-gray-200">
@@ -950,6 +954,7 @@ const SettingsPage = () => {
                     <option value="paste">{t('settings.consoleInputPaste')}</option>
                   </select>
                 </div>
+                )}
 
                 {/* 转换识别结果 */}
                 <div className="flex items-center justify-between">

--- a/src/settings.jsx
+++ b/src/settings.jsx
@@ -39,6 +39,7 @@ const SettingsPage = () => {
     language: "zh-TW",
     convert_transcription: true,
     asr_profile: "standard",          // 效能模式：standard（最準）/ fast（弱 CPU）
+    console_input_method: "auto",     // 主控台輸入方式：auto（偵測自動切換）/ type（一律逐字打字）/ paste（一律貼上）
     mic_device_id: "",                // 指定麥克風（空=系統預設）
     mic_auto_gain: true,              // 自動增益（AGC）
     typeless_trigger: "default",      // 錄音觸發鍵（issue #12：可自訂避開衝突）
@@ -252,6 +253,7 @@ const SettingsPage = () => {
           language: allSettings.language || "zh-TW", // 默认繁体中文
           convert_transcription: allSettings.convert_transcription !== false, // 默认转换
           asr_profile: allSettings.asr_profile || "standard",
+          console_input_method: allSettings.console_input_method || "auto",
           mic_device_id: allSettings.mic_device_id || "",
           mic_auto_gain: allSettings.mic_auto_gain !== false,
           typeless_trigger: allSettings.typeless_trigger || "default",
@@ -925,6 +927,27 @@ const SettingsPage = () => {
                   >
                     <option value="standard">{t('settings.asrProfileStandard')}</option>
                     <option value="fast">{t('settings.asrProfileFast')}</option>
+                  </select>
+                </div>
+
+                {/* 主控台輸入方式：自動 / 一律逐字打字 / 一律貼上 */}
+                <div className="flex items-center justify-between">
+                  <div>
+                    <label className="text-sm font-medium text-gray-800 dark:text-gray-200">
+                      {t('settings.consoleInputMethod')}
+                    </label>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                      {t('settings.consoleInputMethodDesc')}
+                    </p>
+                  </div>
+                  <select
+                    value={settings.console_input_method || 'auto'}
+                    onChange={(e) => handleSettingChange('console_input_method', e.target.value)}
+                    className="px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                  >
+                    <option value="auto">{t('settings.consoleInputAuto')}</option>
+                    <option value="type">{t('settings.consoleInputType')}</option>
+                    <option value="paste">{t('settings.consoleInputPaste')}</option>
                   </select>
                 </div>
 


### PR DESCRIPTION
## 問題
在 Windows 的 cmd、PowerShell 等「主控台視窗」中，講完話辨識成功，但文字**不會輸入到游標處**（一般視窗如記事本、瀏覽器、編輯器則正常）。

## 根本原因
`src/helpers/clipboard.js` 的 `focusAndPasteFast()` 用 `WScript.Shell.SendKeys('^v')` 送 Ctrl+V。SendKeys 是高層訊息模擬，**主控台視窗（conhost）不會把它當成貼上指令**，因此貼不進去（若使用者又關閉 cmd 的「Ctrl 快捷鍵貼上」選項則更完全無效）。

## 修正
新增 `focusAndTypeUnicode(text)`：用 **SendInput + KEYEVENTF_UNICODE 逐字打字**（模擬真實鍵盤輸入）。這種方式任何視窗都能正確輸入，包含 cmd / PowerShell / 遊戲等，且不依賴目標視窗的貼上設定。

`pasteText()` 在 Windows 改為**優先用逐字打字**，失敗時才回退原本的 `focusAndPasteFast()`（Ctrl+V）。

- 逐字打字經由既有的常駐 PowerShell 執行，沿用 `Restore-Fg` 還原焦點邏輯。
- 文字以 UTF-8 base64 傳入 PowerShell，避免引號 / 特殊字元問題；中文為 BMP 字元，`(ushort)c` 直接對應 UTF-16 碼位。
- 中文一句話約 0.x 秒，速度感覺不出差異。

## 測試
- ✅ cmd.exe：可正確輸入（原本無法）
- ✅ PowerShell：可正確輸入
- ✅ 記事本 / 瀏覽器 / 編輯器：正常
- 變更範圍僅 Windows 路徑，macOS / Linux 不受影響

## 影響檔案
`src/helpers/clipboard.js`（+22 / -2）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a console input method setting with Automatic, Always type, and Always paste options.
  * Added localized descriptions and labels in English, Simplified Chinese, and Traditional Chinese.
* **Bug Fixes**
  * Improved Windows clipboard handling for Unicode text, console prompts, and shell completion.
  * Text entry now uses the selected method with smarter confirmation, timeouts, and fallback behavior.
  * Improved focus restoration and recovery from input, clipboard, and shell errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->